### PR TITLE
Team numbers will show correctly

### DIFF
--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -1,9 +1,4 @@
-import {
-  useEventMatch,
-  useEventMatches,
-  useEventTeams,
-  useTeam,
-} from "~hooks/robotevents";
+import { useEventMatches, useEventTeams } from "~hooks/robotevents";
 import { Rule, useRulesForProgram } from "~utils/hooks/rules";
 import { Select, TextArea } from "~components/Input";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -76,11 +71,13 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
 
   const rules = useRulesForProgram(event?.program.code);
 
+  // Find all teams and matches at the event
   const { data: teams } = useEventTeams(event);
   const { data: matches } = useEventMatches(event, division);
 
-  const { data: team } = useTeam(initialTeam?.id, event?.program.code);
-  const { data: match } = useEventMatch(event, division, initialMatch?.id);
+  // Initialise current team and match
+  const [team, setTeam] = useState(initialTeam);
+  const [match, setMatch] = useState(initialMatch);
 
   const [incident, setIncident] = useState<RichIncident>({
     time: new Date(),
@@ -95,17 +92,11 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
 
   useEffect(() => {
     setIncidentField("team", team);
-    setIncidentField("match", match);
-  }, [team, match]);
+    setTeam(team);
 
-  useEffect(() => {
-    if (initialMatch) {
-      setIncidentField("match", initialMatch);
-    }
-    if (initialTeam) {
-      setIncidentField("team", initialTeam);
-    }
-  }, [initialMatch, initialTeam]);
+    setIncidentField("match", match);
+    setMatch(match);
+  }, [team, match]);
 
   const issues = useMemo(() => getIssues(incident), [incident]);
   const canSave = useMemo(() => {
@@ -124,20 +115,24 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
 
   const onChangeIncidentTeam = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const team = teams?.find((t) => t.number === e.target.value);
-      if (!team) return;
+      const newTeam = teams?.find((t) => t.number === e.target.value);
+      if (!newTeam) return;
 
-      setIncidentField("team", team);
+      setIncidentField("team", newTeam);
+      setTeam(newTeam);
     },
     [teams]
   );
 
   const onChangeIncidentMatch = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const match = matches?.find((m) => m.id.toString() === e.target.value);
-      if (!match) return;
+      const newMatch = matches?.find((m) => m.id.toString() === e.target.value);
+      if (!newMatch) return;
 
-      setIncidentField("match", match);
+      setIncidentField("match", newMatch);
+      setMatch(newMatch);
+      // Reset the selected team if a new match is selected
+      setTeam(null);
     },
     [matches]
   );

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -98,6 +98,17 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
     setMatch(match);
   }, [team, match]);
 
+  useEffect(() => {
+    if (initialMatch) {
+      setIncidentField("match", initialMatch);
+      setMatch(initialMatch);
+    }
+    if (initialTeam) {
+      setIncidentField("team", initialTeam);
+      setTeam(initialTeam);
+    }
+  }, [initialMatch, initialTeam]);
+
   const issues = useMemo(() => getIssues(incident), [incident]);
   const canSave = useMemo(() => {
     return issues.every((i) => i.type === "warning");
@@ -183,11 +194,10 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
       const packed = packIncident(incident);
       mutate(packed, {
         onSuccess: () => {
-          setMatch(null);
+          // Do not reset match, for ease of use.
           setTeam(null);
 
           setIncidentField("team", null);
-          setIncidentField("match", null);
           setIncidentField("notes", "");
           setIncidentField("rules", []);
           setIncidentField("outcome", IncidentOutcome.Minor);

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -183,6 +183,14 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
       const packed = packIncident(incident);
       mutate(packed, {
         onSuccess: () => {
+          setMatch(null);
+          setTeam(null);
+
+          setIncidentField("team", null);
+          setIncidentField("match", null);
+          setIncidentField("notes", "");
+          setIncidentField("rules", []);
+          setIncidentField("outcome", IncidentOutcome.Minor);
           setOpen(false);
         },
       });

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -31,8 +31,8 @@ function getIssues(incident: RichIncident): Issue[] {
 
   if (!incident.team || !incident.match) {
     issues.push({
-      message: "Must select at least team and match",
-      type: "error",
+      message: "Please select team and match",
+      type: "warning",
     });
     return issues;
   }
@@ -43,8 +43,8 @@ function getIssues(incident: RichIncident): Issue[] {
 
   if (!hasTeam && incident.match && incident.team) {
     issues.push({
-      message: "Team not in match",
-      type: "warning",
+      message: "Team not in selected match",
+      type: "error",
     });
   }
 


### PR DESCRIPTION
Fix issue #8 and #10

Also will reset the values after submitting a violation, so that the user can input new values for a new team.

Will not reset the match number, to make it easier to submit multiple violations for different teams in the same match.

