### PR TITLE
Virtualize team and match lists to significantly improve performance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "react-dom": "^18.2.0",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.20.0",
+        "react-virtualized-auto-sizer": "^1.0.20",
+        "react-window": "^1.8.10",
         "robotevents": "^3.1.0",
         "sort-by": "^1.2.0",
         "tailwind-merge": "^2.0.0",
@@ -27,6 +29,7 @@
       "devDependencies": {
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
+        "@types/react-window": "^1.8.8",
         "@typescript-eslint/eslint-plugin": "^6.10.0",
         "@typescript-eslint/parser": "^6.10.0",
         "@vitejs/plugin-react": "^4.2.0",
@@ -2895,6 +2898,15 @@
       "version": "18.2.17",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
       "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -6283,6 +6295,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7252,6 +7269,31 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.20.tgz",
+      "integrity": "sha512-OdIyHwj4S4wyhbKHOKM1wLSj/UDXm839Z3Cvfg2a9j+He6yDa6i5p0qQvEiCnyQlGO/HyfSnigQwuxvYalaAXA==",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0-rc"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.10.tgz",
+      "integrity": "sha512-Y0Cx+dnU6NLa5/EvoHukUD0BklJ8qITCtVEPY1C/nL8wwoZ0b5aEw8Ff1dOVHw7fCzMt55XfJDd8S8W8LCaUCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.20.0",
+    "react-virtualized-auto-sizer": "^1.0.20",
+    "react-window": "^1.8.10",
     "robotevents": "^3.1.0",
     "sort-by": "^1.2.0",
     "tailwind-merge": "^2.0.0",
@@ -29,6 +31,7 @@
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
+    "@types/react-window": "^1.8.8",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -8,7 +8,10 @@ export const Tabs: React.FC<TabsProps> = ({ children, ...props }) => {
   const [activeTab, setActiveTab] = React.useState(0);
 
   return (
-    <div {...props}>
+    <div
+      {...props}
+      className={twMerge("flex flex-col flex-1", props.className)}
+    >
       <nav role="tablist" className="flex gap-4 max-w-full py-2">
         {Object.keys(children).map((key, index) => (
           <button
@@ -27,7 +30,7 @@ export const Tabs: React.FC<TabsProps> = ({ children, ...props }) => {
           </button>
         ))}
       </nav>
-      <div role="tabpanel" className="mt-4">
+      <div role="tabpanel" className="flex-1 flex flex-col">
         {Object.values(children)[activeTab]}
       </div>
     </div>

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -19,6 +19,9 @@ import { EventMatchDialog } from "./dialogs/match";
 import { ClickableMatch } from "~components/ClickableMatch";
 import { Dialog, DialogBody, DialogMode } from "~components/Dialog";
 
+import { FixedSizeList as List } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
+
 export type MainTabProps = {
   event: Event;
 };
@@ -59,39 +62,56 @@ const EventTeamsTab: React.FC<MainTabProps> = ({ event }) => {
   }, [incidents]);
 
   return (
-    <section>
+    <section className="flex-1">
       <Spinner show={isLoading} />
-      <ul>
-        {teams?.map((team) => (
-          <li key={team.number}>
-            <Link
-              to={`/${event.sku}/team/${team.number}`}
-              className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
-            >
-              <div className="flex-1">
-                <p className="text-emerald-400 font-mono">{team.number}</p>
-                <p className="overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
-                  {team.team_name}
-                </p>
-              </div>
-              <p className="h-full w-32 px-2 flex items-center">
-                <span className="text-red-400 mr-4">
-                  <FlagIcon height={24} className="inline" />
-                  <span className="font-mono ml-2">
-                    {majorIncidents.get(team.number) ?? 0}
-                  </span>
-                </span>
-                <span className="text-yellow-400">
-                  <ExclamationTriangleIcon height={24} className="inline" />
-                  <span className="font-mono ml-2">
-                    {minorIncidents.get(team.number) ?? 0}
-                  </span>
-                </span>
-              </p>
-            </Link>
-          </li>
-        ))}
-      </ul>
+      <AutoSizer>
+        {(size) => (
+          <List
+            width={size.width}
+            height={size.height}
+            itemCount={teams?.length ?? 0}
+            itemSize={64}
+          >
+            {({ index, style }) => {
+              const team = teams?.[index]!;
+              return (
+                <div style={style} key={team.id}>
+                  <Link
+                    to={`/${event.sku}/team/${team.number}`}
+                    className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
+                  >
+                    <div className="flex-1">
+                      <p className="text-emerald-400 font-mono">
+                        {team.number}
+                      </p>
+                      <p className="overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
+                        {team.team_name}
+                      </p>
+                    </div>
+                    <p className="h-full w-32 px-2 flex items-center">
+                      <span className="text-red-400 mr-4">
+                        <FlagIcon height={24} className="inline" />
+                        <span className="font-mono ml-2">
+                          {majorIncidents.get(team.number) ?? 0}
+                        </span>
+                      </span>
+                      <span className="text-yellow-400">
+                        <ExclamationTriangleIcon
+                          height={24}
+                          className="inline"
+                        />
+                        <span className="font-mono ml-2">
+                          {minorIncidents.get(team.number) ?? 0}
+                        </span>
+                      </span>
+                    </p>
+                  </Link>
+                </div>
+              );
+            }}
+          </List>
+        )}
+      </AutoSizer>
     </section>
   );
 };
@@ -118,17 +138,31 @@ const EventMatchesTab: React.FC<MainTabProps> = ({ event }) => {
         open={open}
         setOpen={setOpen}
       />
-      <section>
+      <section className="flex-1">
         <Spinner show={isLoading} />
-        <ul className="flex-1">
-          {matches?.map((match) => (
-            <ClickableMatch
-              match={match}
-              onClick={onClickMatch}
-              key={match.id}
-            />
-          ))}
-        </ul>
+        <AutoSizer>
+          {(size) => (
+            <List
+              width={size.width}
+              height={size.height}
+              itemCount={matches?.length ?? 0}
+              itemSize={64}
+            >
+              {({ index, style }) => {
+                const match = matches?.[index]!;
+                return (
+                  <div style={style}>
+                    <ClickableMatch
+                      match={match}
+                      onClick={onClickMatch}
+                      key={match.id}
+                    />
+                  </div>
+                );
+              }}
+            </List>
+          )}
+        </AutoSizer>
       </section>
     </>
   );
@@ -198,7 +232,7 @@ export const EventPage: React.FC = () => {
   const [incidentDialogOpen, setIncidentDialogOpen] = useState(false);
 
   return event ? (
-    <section className="mt-4">
+    <section className="mt-4 flex flex-col">
       <Button
         onClick={() => setIncidentDialogOpen(true)}
         className="w-full text-center bg-emerald-600"
@@ -210,7 +244,7 @@ export const EventPage: React.FC = () => {
         open={incidentDialogOpen}
         setOpen={setIncidentDialogOpen}
       />
-      <Tabs className="mt-4">
+      <Tabs className="flex-1">
         {{
           Teams: <EventTeamsTab event={event} />,
           Matches: <EventMatchesTab event={event} />,


### PR DESCRIPTION
Uses `react-window` to virtualize match lists for larger events. This will significantly improve performance by reducing the amount of DOM nodes that are needed.