### PR TITLE
Feat/show matches for team

### DIFF
--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -17,6 +17,7 @@ import { Team } from "robotevents/out/endpoints/teams";
 import * as robotevents from "robotevents";
 import { useQuery } from "react-query";
 import { Match } from "robotevents/out/endpoints/matches";
+import { DialogMode } from "~components/constants";
 
 export function useMatchTeams(match?: Match | null) {
   return useQuery(["match_teams", match?.id], async () => {
@@ -33,7 +34,6 @@ export function useMatchTeams(match?: Match | null) {
     );
   });
 }
-import { DialogMode } from "~components/constants";
 
 export type EventMatchDialogProps = {
   matchId: number;

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -1,4 +1,8 @@
-import { useEventMatches, useEventTeams } from "~hooks/robotevents";
+import {
+  useEventMatches,
+  useEventTeams,
+  useEventMatchesForTeam,
+} from "~hooks/robotevents";
 import { Rule, useRulesForProgram } from "~utils/hooks/rules";
 import { Select, TextArea } from "~components/Input";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -88,6 +92,8 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
   const [team, setTeam] = useState(initialTeam);
   const [match, setMatch] = useState(initialMatch);
 
+  const { data: teamMatches } = useEventMatchesForTeam(event, team);
+
   const [incident, setIncident] = useState<RichIncident>({
     time: new Date(),
     division: division ?? 1,
@@ -141,6 +147,8 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
         setTeam(null);
       }
 
+      if (!newTeam) return;
+
       setIncidentField("team", newTeam);
       setTeam(newTeam);
     },
@@ -151,10 +159,15 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newMatch = matches?.find((m) => m.id.toString() === e.target.value);
 
+      console.log(e.target.value);
+      console.log("newmatch", newMatch);
+
       if (e.target.value === "-1") {
         setMatch(null);
         setTeam(null);
       }
+
+      if (!newMatch) return;
 
       setIncidentField("match", newMatch);
       setMatch(newMatch);
@@ -270,11 +283,18 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
             className="max-w-full w-full"
           >
             <option value={-1}>Pick A Match</option>
-            {matches?.map((match) => (
-              <option value={match.id} key={match.id}>
-                {match.name}
-              </option>
-            ))}
+            {team &&
+              teamMatches?.map((match) => (
+                <option value={match.id} key={match.id}>
+                  {match.name}
+                </option>
+              ))}
+            {!team &&
+              matches?.map((match) => (
+                <option value={match.id} key={match.id}>
+                  {match.name}
+                </option>
+              ))}
           </Select>
         </label>
         {incident.match && (

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -136,7 +136,10 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
   const onChangeIncidentTeam = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newTeam = teams?.find((t) => t.number === e.target.value);
-      if (!newTeam) return;
+      if (e.target.value === "-1") {
+        setMatch(null);
+        setTeam(null);
+      }
 
       setIncidentField("team", newTeam);
       setTeam(newTeam);
@@ -147,12 +150,14 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
   const onChangeIncidentMatch = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newMatch = matches?.find((m) => m.id.toString() === e.target.value);
-      if (!newMatch) return;
+
+      if (e.target.value === "-1") {
+        setMatch(null);
+        setTeam(null);
+      }
 
       setIncidentField("match", newMatch);
       setMatch(newMatch);
-      // Reset the selected team if a new match is selected
-      setTeam(null);
     },
     [matches]
   );

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -159,9 +159,6 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const newMatch = matches?.find((m) => m.id.toString() === e.target.value);
 
-      console.log(e.target.value);
-      console.log("newmatch", newMatch);
-
       if (e.target.value === "-1") {
         setMatch(null);
         setTeam(null);


### PR DESCRIPTION
When selecting a team, the 'matches' section will auto populate with matches the team is taking part in.

When selecting a match, the 'teams' section will still auto populate with teams playing in the match.

Selecting 'Pick a Team' or 'Pick a Match' as an option from the drop down will reset the selection menu to all teams and all matches. This allows the user to de-select a match if they do not want one.