### PR TITLE
Hotfix: store match name with incident

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "referee-fyi",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "referee-fyi",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "@tanstack/query-async-storage-persister": "^5.17.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "referee-fyi",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -1,6 +1,5 @@
 import { twMerge } from "tailwind-merge";
 import { IncidentOutcome, IncidentWithID } from "~utils/data/incident";
-import { useEvent, useEventMatch } from "~utils/hooks/robotevents";
 import { IconButton } from "./Button";
 import { TrashIcon } from "@heroicons/react/24/outline";
 import { useDeleteIncident } from "~utils/hooks/incident";
@@ -16,11 +15,7 @@ export type IncidentProps = {
 } & React.HTMLProps<HTMLDivElement>;
 
 export const Incident: React.FC<IncidentProps> = ({ incident, ...props }) => {
-  const { data: event } = useEvent(incident.event);
-  const match = useEventMatch(event, incident.division, incident.match);
-
   const { mutate: onClickDelete } = useDeleteIncident(incident.id);
-
   return (
     <>
       <div
@@ -35,7 +30,7 @@ export const Incident: React.FC<IncidentProps> = ({ incident, ...props }) => {
           <p className="text-sm">
             {[
               incident.team,
-              match?.name ?? "Event-Wide",
+              incident.match?.name ?? "Event-Wide",
               IncidentOutcome[incident.outcome],
             ].join(" • ")}
           </p>

--- a/src/pages/markdown.css
+++ b/src/pages/markdown.css
@@ -11,3 +11,12 @@
   list-style: unset;
   padding-left: 1rem;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 1rem;
+}

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -17,7 +17,10 @@ export type Incident = {
   event: string; // SKU
   division: number; // division ID
 
-  match?: number; // match ID
+  match?: {
+    id: number;
+    name: string;
+  };
   team?: string; // team ID
 
   outcome: IncidentOutcome;
@@ -50,7 +53,10 @@ export type RichIncident = {
 export function packIncident(incident: RichIncident): Incident {
   return {
     ...incident,
-    match: incident.match?.id,
+    match: incident.match ? {
+      id: incident.match.id,
+      name: incident.match.name
+    } : undefined,
     team: incident.team?.number,
     rules: incident.rules.map((rule) => rule.rule),
   };

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -53,10 +53,12 @@ export type RichIncident = {
 export function packIncident(incident: RichIncident): Incident {
   return {
     ...incident,
-    match: incident.match ? {
-      id: incident.match.id,
-      name: incident.match.name
-    } : undefined,
+    match: incident.match
+      ? {
+          id: incident.match.id,
+          name: incident.match.name,
+        }
+      : undefined,
     team: incident.team?.number,
     rules: incident.rules.map((rule) => rule.rule),
   };
@@ -179,7 +181,6 @@ export async function deleteIncident(
   if (updateRemote) {
     await deleteServerIncident(id, incident.event);
   }
-
 }
 
 export async function getAllIncidents(): Promise<IncidentWithID[]> {

--- a/src/utils/data/query.ts
+++ b/src/utils/data/query.ts
@@ -15,7 +15,7 @@ export const queryClient = new QueryClient({
 });
 
 // Cache buster key, used to forcibly invalidate queries
-export const CACHE_BUSTER = "v1";
+export const CACHE_BUSTER = "v2";
 
 export function createIDBPersister(idbValidKey: IDBValidKey = "reactQuery") {
     return {

--- a/src/utils/data/query.ts
+++ b/src/utils/data/query.ts
@@ -1,33 +1,33 @@
 import { QueryClient } from "@tanstack/react-query";
 import { del, get, set } from "idb-keyval";
 import {
-    PersistedClient,
-    Persister,
-} from '@tanstack/react-query-persist-client'
+  PersistedClient,
+  Persister,
+} from "@tanstack/react-query-persist-client";
 
 export const queryClient = new QueryClient({
-    defaultOptions: {
-        queries: {
-            networkMode: "offlineFirst",
-            gcTime: 1000 * 60 * 60 * 24 * 7,
-        }
-    }
+  defaultOptions: {
+    queries: {
+      networkMode: "offlineFirst",
+      gcTime: 1000 * 60 * 60 * 24 * 7,
+    },
+  },
 });
 
 // Cache buster key, used to forcibly invalidate queries
 export const CACHE_BUSTER = "v2";
 
 export function createIDBPersister(idbValidKey: IDBValidKey = "reactQuery") {
-    return {
-        persistClient: async (client: PersistedClient) => {
-            await set(idbValidKey, client)
-        },
-        restoreClient: async () => {
-            return await get<PersistedClient>(idbValidKey)
-        },
-        removeClient: async () => {
-            await del(idbValidKey)
-        },
-    } as Persister
+  return {
+    persistClient: async (client: PersistedClient) => {
+      await set(idbValidKey, client);
+    },
+    restoreClient: async () => {
+      return await get<PersistedClient>(idbValidKey);
+    },
+    removeClient: async () => {
+      await del(idbValidKey);
+    },
+  } as Persister;
 }
 export const persister = createIDBPersister();

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -21,7 +21,9 @@ import { toast } from "~components/Toast";
 import { queryClient } from "./query";
 import { EventEmitter } from "events";
 
-const URL_BASE = import.meta.env.DEV ? "http://localhost:8787" : "https://referee-fyi-share.bren.workers.dev";
+const URL_BASE = import.meta.env.DEV
+  ? "http://localhost:8787"
+  : "https://referee-fyi-share.bren.workers.dev";
 
 export async function getShareData(sku: string, code: string) {
   const response = await fetch(
@@ -32,25 +34,25 @@ export async function getShareData(sku: string, code: string) {
     return null;
   }
 
-  return response.json() as Promise<ShareResponse<WebSocketServerShareInfoMessage>>;
-
-};
+  return response.json() as Promise<
+    ShareResponse<WebSocketServerShareInfoMessage>
+  >;
+}
 
 export type JoinShareOptions = {
   sku: string;
-  code: string
+  code: string;
 };
 
 export async function joinShare({ sku, code }: JoinShareOptions) {
   await set(`share_${sku}`, code);
   queryClient.invalidateQueries({ queryKey: ["share_code"] });
-};
+}
 
 export async function leaveShare(sku: string) {
   await del(`share_${sku}`);
   queryClient.invalidateQueries({ queryKey: ["share_code"] });
-};
-
+}
 
 export async function createShare(
   incidents: EventIncidents
@@ -68,11 +70,11 @@ export async function createShare(
       return response.json();
     }
 
-    const body = await response.json() as ShareResponse<CreateShareResponse>;
+    const body = (await response.json()) as ShareResponse<CreateShareResponse>;
 
     if (!body.success) {
       return body;
-    };
+    }
 
     await set(`share_${incidents.sku}`, body.data.code);
     queryClient.invalidateQueries({ queryKey: ["share_code"] });
@@ -87,7 +89,6 @@ export async function createShare(
   }
 }
 
-
 export async function addServerIncident(incident: IncidentWithID) {
   const code = await get<string>(`share_${incident.event}`);
   const userId = await ShareConnection.getUserId();
@@ -97,7 +98,8 @@ export async function addServerIncident(incident: IncidentWithID) {
   }
 
   const url = new URL(
-    `/api/share/${incident.event}/${code}/incident`, URL_BASE
+    `/api/share/${incident.event}/${code}/incident`,
+    URL_BASE
   );
 
   url.searchParams.set("user_id", userId);
@@ -117,7 +119,8 @@ export async function editServerIncident(incident: IncidentWithID) {
   }
 
   const url = new URL(
-    `/api/share/${incident.event}/${code}/incident`, URL_BASE
+    `/api/share/${incident.event}/${code}/incident`,
+    URL_BASE
   );
 
   url.searchParams.set("user_id", userId);
@@ -164,8 +167,6 @@ export interface ShareConnection {
   ): this;
 }
 
-
-
 export class ShareConnection extends EventEmitter {
   ws: WebSocket | null = null;
 
@@ -175,10 +176,9 @@ export class ShareConnection extends EventEmitter {
   user: ShareUser | null = null;
   owner: string | null = null;
 
-  users: string[] = []
+  users: string[] = [];
 
   public setup(sku: string, code: string, user: Omit<ShareUser, "id">) {
-
     if (this.sku === sku && this.code === code) {
       return;
     }
@@ -289,9 +289,9 @@ export class ShareConnection extends EventEmitter {
         }
         case "server_user_remove": {
           toast({ type: "warn", message: `${data.user} left.` });
-          const index = this.users.findIndex(u => u === data.user);
+          const index = this.users.findIndex((u) => u === data.user);
           if (index > -1) {
-            this.users.splice(index, 1)
+            this.users.splice(index, 1);
           }
           break;
         }
@@ -303,9 +303,8 @@ export class ShareConnection extends EventEmitter {
         }
       }
 
-      this.emit("message", data)
-
-    } catch (e) { }
+      this.emit("message", data);
+    } catch (e) {}
   }
 
   public cleanup() {

--- a/src/utils/hooks/debounce.ts
+++ b/src/utils/hooks/debounce.ts
@@ -1,23 +1,29 @@
 import { useCallback, useRef, useState } from "react";
 
-export function useDebounce<A extends unknown[]>(action: (...args: A) => void, wait: number = 250): (...args: A) => void {
-    const [lastRun, setLastRun] = useState<number>(0);
-    const timer = useRef<NodeJS.Timeout | undefined>();
+export function useDebounce<A extends unknown[]>(
+  action: (...args: A) => void,
+  wait: number = 250
+): (...args: A) => void {
+  const [lastRun, setLastRun] = useState<number>(0);
+  const timer = useRef<NodeJS.Timeout | undefined>();
 
-    const exec = useCallback((...args: A) => {
-        setLastRun(performance.now());
-        action(...args);
-    }, [action])
+  const exec = useCallback(
+    (...args: A) => {
+      setLastRun(performance.now());
+      action(...args);
+    },
+    [action]
+  );
 
-    return (...args) => {
-        const now = performance.now();
-        const timeUntil = wait - (now - lastRun);
+  return (...args) => {
+    const now = performance.now();
+    const timeUntil = wait - (now - lastRun);
 
-        if (timeUntil < 0) {
-            exec(...args)
-        } else {
-            clearTimeout(timer.current);
-            timer.current = setTimeout(() => exec(...args), timeUntil)
-        }
+    if (timeUntil < 0) {
+      exec(...args);
+    } else {
+      clearTimeout(timer.current);
+      timer.current = setTimeout(() => exec(...args), timeUntil);
     }
-}; 
+  };
+}

--- a/src/utils/hooks/history.ts
+++ b/src/utils/hooks/history.ts
@@ -35,7 +35,7 @@ export function useRecentEvents(limit?: number) {
       return events.slice(0, limit);
     },
     staleTime: 0,
-    refetchOnMount: "always"
+    refetchOnMount: "always",
   });
 }
 
@@ -47,16 +47,18 @@ export function useRecentRules(limit?: number) {
       return rules.slice(0, limit);
     },
     staleTime: 0,
-    refetchOnMount: "always"
-  })
+    refetchOnMount: "always",
+  });
 }
 
 export function useAddEventVisited() {
   return useMutation({
     mutationFn: async (event: EventData) => {
-      const events = (await getRecentEvents()).filter((e) => e.sku !== event.sku);
+      const events = (await getRecentEvents()).filter(
+        (e) => e.sku !== event.sku
+      );
       await set("event_history", [event, ...events]);
-    }
+    },
   });
 }
 
@@ -71,6 +73,6 @@ export function useAddRecentRules() {
         rules.every((b) => b.rule !== a.rule)
       );
       await set("rule_history", [...rules, ...recent]);
-    }
+    },
   });
 }

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -20,7 +20,7 @@ export function useIncident(id: string | undefined | null) {
       }
       return getIncident(id);
     },
-    staleTime: 0
+    staleTime: 0,
   });
 }
 
@@ -30,7 +30,7 @@ export function useNewIncident() {
       const id = await newIncident(incident);
       await queryClient.invalidateQueries({ queryKey: ["incidents"] });
       return id;
-    }
+    },
   });
 }
 
@@ -43,7 +43,7 @@ export function useEventIncidents(sku: string | undefined | null) {
       }
       return getIncidentsByEvent(sku);
     },
-    staleTime: 0
+    staleTime: 0,
   });
 }
 
@@ -52,9 +52,9 @@ export function useDeleteIncident(id: string, updateRemote?: boolean) {
     mutationFn: async (_: unknown) => {
       await deleteIncident(id, updateRemote);
       await queryClient.invalidateQueries({ queryKey: ["incidents"] });
-    }
-  })
-};
+    },
+  });
+}
 
 export function useTeamIncidents(team: string | undefined | null) {
   return useQuery<IncidentWithID[]>({
@@ -65,7 +65,7 @@ export function useTeamIncidents(team: string | undefined | null) {
       }
       return getIncidentsByTeam(team);
     },
-    staleTime: 0
+    staleTime: 0,
   });
 }
 
@@ -73,24 +73,22 @@ export function useTeamIncidentsByEvent(
   team: string | undefined | null,
   sku: string | undefined | null
 ) {
-  return useQuery<IncidentWithID[]>(
-    {
-      queryKey: ["incidents", "team", team, "event", sku],
-      queryFn: async () => {
-        if (!team || !sku) {
-          return [];
-        }
+  return useQuery<IncidentWithID[]>({
+    queryKey: ["incidents", "team", team, "event", sku],
+    queryFn: async () => {
+      if (!team || !sku) {
+        return [];
+      }
 
-        const incidents = await getIncidentsByTeam(team);
-        if (!sku || !incidents) {
-          return [];
-        }
+      const incidents = await getIncidentsByTeam(team);
+      if (!sku || !incidents) {
+        return [];
+      }
 
-        return incidents.filter((incident) => incident.event === sku);
-      },
-      staleTime: 0
-    }
-  );
+      return incidents.filter((incident) => incident.event === sku);
+    },
+    staleTime: 0,
+  });
 }
 
 export type TeamIncidentsByMatch = {
@@ -104,7 +102,6 @@ export function useTeamIncidentsByMatch(
   return useQuery({
     queryKey: ["incidents", "match", matchData?.id],
     queryFn: async () => {
-
       if (!matchData) {
         return [];
       }
@@ -128,6 +125,6 @@ export function useTeamIncidentsByMatch(
 
       return incidentsByTeam;
     },
-    staleTime: 0
-  })
+    staleTime: 0,
+  });
 }

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -1,8 +1,16 @@
 import * as robotevents from "robotevents";
 import { UseQueryResult, useQuery } from "@tanstack/react-query";
-import { Round, type MatchData, Color } from "robotevents/out/endpoints/matches";
+import {
+  Round,
+  type MatchData,
+  Color,
+} from "robotevents/out/endpoints/matches";
 import { ProgramAbbr } from "robotevents/out/endpoints/programs";
-import { Team, TeamData, TeamOptionsFromEvent } from "robotevents/out/endpoints/teams";
+import {
+  Team,
+  TeamData,
+  TeamOptionsFromEvent,
+} from "robotevents/out/endpoints/teams";
 import { EventData } from "robotevents/out/endpoints/events";
 import { useMemo } from "react";
 
@@ -22,8 +30,8 @@ export function useEvent(sku: string) {
       const event = await robotevents.events.get(sku);
       return event?.getData();
     },
-    staleTime: Infinity
-  })
+    staleTime: Infinity,
+  });
 }
 
 export function useTeam(
@@ -40,8 +48,8 @@ export function useTeam(
       const team = await robotevents.teams.get(numberOrID, program);
       return team?.getData();
     },
-    staleTime: 1000 * 60 * 60 * 4
-  })
+    staleTime: 1000 * 60 * 60 * 4,
+  });
 }
 
 export function useEventTeams(
@@ -57,9 +65,9 @@ export function useEventTeams(
 
       const event = new robotevents.events.Event(eventData);
       const teams = await event.teams({ registered: true, ...options });
-      return teams.array().map(team => team.getData());
+      return teams.array().map((team) => team.getData());
     },
-    staleTime: 1000 * 60 * 60
+    staleTime: 1000 * 60 * 60,
   });
 }
 
@@ -98,11 +106,14 @@ export function useEventMatches(
       const event = new robotevents.events.Event(eventData);
       const matches = await event.matches(division);
 
-      return matches.array().map(match => match.getData()).sort(logicalMatchComparison);
+      return matches
+        .array()
+        .map((match) => match.getData())
+        .sort(logicalMatchComparison);
     },
-    staleTime: 1000 * 60
+    staleTime: 1000 * 60,
   });
-};
+}
 
 export function useEventMatchesForTeam(
   event: EventData | null | undefined,
@@ -124,9 +135,11 @@ export function useEventMatchesForTeam(
         );
       }
 
-      return matches.map(match => match.getData()).sort(logicalMatchComparison);
+      return matches
+        .map((match) => match.getData())
+        .sort(logicalMatchComparison);
     },
-    staleTime: 1000 * 60
+    staleTime: 1000 * 60,
   });
 }
 
@@ -140,8 +153,8 @@ export function useMatchTeams(match?: MatchData | null) {
       .map((alliance) => alliance.teams.map((t) => t.team.name))
       .flat();
 
-    return teams
-  }, [match])
+    return teams;
+  }, [match]);
 }
 
 export function useEventMatch(
@@ -155,22 +168,25 @@ export function useEventMatch(
   return matchArray.find((m) => m.id === match) ?? null;
 }
 
-export function useEventTeam(event: EventData | null | undefined, number: string | null | undefined) {
+export function useEventTeam(
+  event: EventData | null | undefined,
+  number: string | null | undefined
+) {
   const { data: teams } = useEventTeams(event);
 
   if (!number) {
     return undefined;
   }
 
-  return teams?.find(team => team.number === number);
-};
+  return teams?.find((team) => team.number === number);
+}
 
 export function useEventsToday(): UseQueryResult<EventData[]> {
   return useQuery({
     queryKey: ["events_today"],
     queryFn: async () => {
-      const currentSeasons = (["VRC", "VEXU", "VIQRC"] as const).map((program) =>
-        robotevents.seasons.current(program)
+      const currentSeasons = (["VRC", "VEXU", "VIQRC"] as const).map(
+        (program) => robotevents.seasons.current(program)
       ) as number[];
       const today = new Date();
 
@@ -186,8 +202,8 @@ export function useEventsToday(): UseQueryResult<EventData[]> {
       });
 
       return events
-        .map(event => event.getData())
+        .map((event) => event.getData())
         .sort((a, b) => a.name.localeCompare(b.name));
-    }
-  })
+    },
+  });
 }

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -130,33 +130,6 @@ export function useEventMatchesForTeam(
   });
 }
 
-
-export function useEventMatchesForTeamNumber(
-  event: EventData | null | undefined,
-  teamData: TeamData | null | undefined,
-  color?: Color
-) {
-  return useQuery({
-    queryKey: ["team_matches", event?.sku, teamData?.number],
-    queryFn: async () => {
-      if (!event || !teamData) {
-        return null;
-      }
-      const team = new Team(teamData);
-      let matches = (await team.matches({ event: [event.id] })).array();
-
-      if (color) {
-        matches = matches.filter((match) =>
-          match.alliance(color).teams.some((t) => t.team.id === team.id)
-        );
-      }
-
-      return matches.map(match => match.getData()).sort(logicalMatchComparison);
-    },
-    staleTime: 1000 * 60
-  });
-}
-
 export function useMatchTeams(match?: MatchData | null) {
   return useMemo(() => {
     if (!match) {

--- a/src/utils/hooks/rules.ts
+++ b/src/utils/hooks/rules.ts
@@ -34,8 +34,8 @@ export function useRules(): UseQueryResult<Rules> {
       }
       return response.json() as Promise<Rules>;
     },
-    staleTime: 1000 * 60 * 60 * 24
-  })
+    staleTime: 1000 * 60 * 60 * 24,
+  });
 }
 
 export function useGameRules(game: string): Game | undefined {

--- a/worker/types/EventIncidents.d.ts
+++ b/worker/types/EventIncidents.d.ts
@@ -12,7 +12,10 @@ export type Incident = {
     event: string; // SKU
     division: number; // division ID
 
-    match?: number; // match ID
+    match?: {
+        name: string;
+        id: number;
+    };
     team?: string; // team number
 
     outcome: IncidentOutcome;


### PR DESCRIPTION
There appears to be a bug with RobotEvents where different match IDs are reported before and after a match is scored. To fix this, let's just store the match name, and display that at the same time.