### PR TITLE
UI Tweaks

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -27,8 +27,12 @@ export const IconButton: React.FC<IconButtonProps> = ({ icon, ...props }) => {
 };
 
 const ButtonClasses: { [K in ButtonMode]: string } = {
-  [ButtonMode.Normal]: "",
-  [ButtonMode.None]: "bg-transparent",
+  [ButtonMode.None]: "",
+  [ButtonMode.Transparent]: "w-full bg-transparent",
+  [ButtonMode.Normal]: "w-full text-center",
+  [ButtonMode.Primary]:
+    "w-full text-center bg-emerald-600 active:bg-emerald-700",
+  [ButtonMode.Dangerous]: "w-full text-center bg-red-600 active:bg-red-700",
 };
 
 export type ButtonProps = BaseButtonProps & {
@@ -44,7 +48,7 @@ export const Button: React.FC<ButtonProps> = ({
       {...props}
       className={twMerge(
         "rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2",
-        "active:bg-zinc-600 disabled:bg-zinc-300 disabled:cursor-not-allowed",
+        " disabled:bg-zinc-300 disabled:cursor-not-allowed",
         ButtonClasses[mode],
         props.className
       )}

--- a/src/components/ClickableMatch.tsx
+++ b/src/components/ClickableMatch.tsx
@@ -37,10 +37,10 @@ export const ClickableMatch: React.FC<ClickableMatch> = ({
       className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
     >
       <Button
-        mode={ButtonMode.None}
+        mode={ButtonMode.Transparent}
         data-matchid={match.id}
         onClick={onClick}
-        className="flex-1"
+        className="flex-1 active:bg-zinc-600"
         id={id}
       >
         <p>{match.name}</p>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -21,9 +21,9 @@ export const Tabs: React.FC<TabsProps> = ({ children, ...props }) => {
             aria-controls={`panel-${key}`}
             onClick={() => setActiveTab(index)}
             className={twMerge(
-              "text-zinc-50 flex-1 text-center py-2 px-4",
+              "text-zinc-50 flex-1 text-center py-2 px-4 active:bg-zinc-600 first:rounded-tl-md last::rounded-tr-md",
               index === activeTab &&
-                "text-emerald-400 border-b border-b-emerald-400 "
+                "text-emerald-400 border-b-2 border-emerald-400"
             )}
           >
             {key}

--- a/src/components/constants.tsx
+++ b/src/components/constants.tsx
@@ -1,5 +1,8 @@
 export enum ButtonMode {
   Normal,
+  Primary,
+  Dangerous,
+  Transparent,
   None,
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -26,3 +26,7 @@ body:has(dialog[open]) {
 summary::-webkit-details-marker {
   display: none;
 }
+
+* {
+  -webkit-tap-highlight-color: transparent;
+}

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -1,6 +1,6 @@
 import { useCurrentDivision, useCurrentEvent } from "~hooks/state";
 import { useEventMatch, useEventMatches } from "~hooks/robotevents";
-import { Button } from "~components/Button";
+import { Button, IconButton } from "~components/Button";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -15,7 +15,7 @@ import { Dialog, DialogBody, DialogHeader } from "~components/Dialog";
 import { useTeamIncidentsByMatch } from "~utils/hooks/incident";
 import { EventNewIncidentDialog } from "./new";
 import { IncidentOutcome, IncidentWithID } from "~utils/data/incident";
-import { DialogMode } from "~components/constants";
+import { ButtonMode, DialogMode } from "~components/constants";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { MatchContext } from "~components/Context";
 import { Incident } from "~components/Incident";
@@ -105,7 +105,8 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
           })}
         </ul>
         <Button
-          className="bg-emerald-600 active:bg-black/10 p-2 flex items-center"
+          mode={ButtonMode.Primary}
+          className="flex items-center w-max"
           onClick={onClickFlag}
         >
           <FlagIcon height={20} className="mr-2" />
@@ -189,25 +190,23 @@ export const EventMatchDialog: React.FC<EventMatchDialogProps> = ({
         <DialogHeader title="Matches" onClose={() => setOpen(false)} />
         <DialogBody>
           <nav className="flex items-center">
-            <Button
+            <IconButton
+              icon={<ArrowLeftIcon height={24} />}
               onClick={onClickPrevMatch}
               className={twMerge(
                 "bg-transparent",
                 prevMatch ? "visible" : "invisible"
               )}
-            >
-              <ArrowLeftIcon height={24} />
-            </Button>
+            />
             <h1 className="flex-1 text-xl text-center">{match?.name}</h1>
-            <Button
+            <IconButton
+              icon={<ArrowRightIcon height={24} />}
               onClick={onClickNextMatch}
               className={twMerge(
                 "bg-transparent",
                 nextMatch ? "visible" : "invisible"
               )}
-            >
-              <ArrowRightIcon height={24} />
-            </Button>
+            />
           </nav>
           <Spinner show={!match} />
           {match && (

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -1,6 +1,6 @@
 import { useCurrentDivision, useCurrentEvent } from "~hooks/state";
 import { useEventMatch, useEventMatches } from "~hooks/robotevents";
-import { Button, IconButton } from "~components/Button";
+import { Button } from "~components/Button";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -104,11 +104,13 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
             );
           })}
         </ul>
-        <IconButton
-          className="bg-emerald-600 active:bg-black/10 p-2"
+        <Button
+          className="bg-emerald-600 active:bg-black/10 p-2 flex items-center"
           onClick={onClickFlag}
-          icon={<FlagIcon height={20} />}
-        />
+        >
+          <FlagIcon height={20} className="mr-2" />
+          <span>New</span>
+        </Button>
       </summary>
       {incidents.map((incident) => (
         <Incident incident={incident} key={incident.id} />

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -45,8 +45,10 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
   const division = useCurrentDivision();
 
   const rules = useRulesForProgram(event?.program.code);
-  const { data: recentRules } = useRecentRules(4);
-  const { mutateAsync: addRecentRules } = useAddRecentRules();
+  const { data: recentRules } = useRecentRules(event?.program.code ?? "VRC", 4);
+  const { mutateAsync: addRecentRules } = useAddRecentRules(
+    event?.program.code ?? "VRC"
+  );
 
   // Find all teams and matches at the event
   const { data: teams, isLoading: isLoadingTeams } = useEventTeams(event);

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { useEventMatches, useEventTeams } from "~hooks/robotevents";
+import { useDivisionTeams, useEventMatches } from "~hooks/robotevents";
 import { Spinner } from "~components/Spinner";
 import { Tabs } from "~components/Tabs";
 import { EventData } from "robotevents/out/endpoints/events";
@@ -22,7 +22,7 @@ import { EventNewIncidentDialog } from "./dialogs/new";
 import { EventMatchDialog } from "./dialogs/match";
 import { ClickableMatch } from "~components/ClickableMatch";
 import { Dialog, DialogBody } from "~components/Dialog";
-import { DialogMode } from "~components/constants";
+import { ButtonMode, DialogMode } from "~components/constants";
 import { FixedSizeList as List } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { useAddEventVisited } from "~utils/hooks/history";
@@ -43,9 +43,15 @@ export type MainTabProps = {
 };
 
 const EventTeamsTab: React.FC<MainTabProps> = ({ event }) => {
-  const { data: teams, isLoading } = useEventTeams(event);
-
+  const division = useCurrentDivision();
+  const {
+    data: divisionTeams,
+    isLoading,
+    isPaused,
+  } = useDivisionTeams(event, division);
   const { data: incidents } = useEventIncidents(event.sku);
+
+  const teams = divisionTeams?.teams ?? [];
 
   const majorIncidents = useMemo(() => {
     if (!incidents) return new Map<string, number>();
@@ -79,7 +85,7 @@ const EventTeamsTab: React.FC<MainTabProps> = ({ event }) => {
 
   return (
     <section className="flex-1">
-      <Spinner show={isLoading} />
+      <Spinner show={isLoading || isPaused} />
       <AutoSizer>
         {(size) => (
           <List
@@ -308,7 +314,8 @@ const EventManageTab: React.FC<MainTabProps> = ({ event }) => {
                 />
               </label>
               <Button
-                className="w-full mt-4 bg-emerald-400 disabled:bg-zinc-400 text-center"
+                className="disabled:bg-zinc-400 mt-4"
+                mode={ButtonMode.Primary}
                 disabled={!shareName}
                 onClick={onClickShare}
               >
@@ -380,7 +387,7 @@ export const EventPage: React.FC = () => {
       <section className="mt-4 flex flex-col">
         <Button
           onClick={() => setIncidentDialogOpen(true)}
-          className="w-full text-center bg-emerald-600"
+          mode={ButtonMode.Primary}
         >
           <FlagIcon height={20} className="inline mr-2 " />
           New Entry

--- a/src/pages/events/team.tsx
+++ b/src/pages/events/team.tsx
@@ -107,7 +107,7 @@ export const EventTeamsPage: React.FC = () => {
       />
       <Spinner show={isLoading} />
       {team && (
-        <header className="p-4">
+        <header className="mt-4">
           <Button
             onClick={() => setIncidentDialogOpen(true)}
             className="w-full text-center bg-emerald-600"
@@ -115,12 +115,11 @@ export const EventTeamsPage: React.FC = () => {
             <FlagIcon height={20} className="inline mr-2 " />
             New Entry
           </Button>
-          <h1 className="text-xl overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
+          <h1 className="text-xl overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose mt-4">
             <span className="font-mono text-emerald-400">{team?.number}</span>
             {" • "}
             <span className="">{team.team_name}</span>
           </h1>
-
           <p className="italic">{teamLocation}</p>
         </header>
       )}

--- a/src/pages/events/team.tsx
+++ b/src/pages/events/team.tsx
@@ -14,6 +14,7 @@ import { Incident } from "~components/Incident";
 import { EventNewIncidentDialog } from "./dialogs/new";
 import { Button } from "~components/Button";
 import { FlagIcon } from "@heroicons/react/20/solid";
+import { ButtonMode } from "~components/constants";
 
 type EventTeamsTabProps = {
   event: EventData | null | undefined;
@@ -110,7 +111,7 @@ export const EventTeamsPage: React.FC = () => {
         <header className="mt-4">
           <Button
             onClick={() => setIncidentDialogOpen(true)}
-            className="w-full text-center bg-emerald-600"
+            mode={ButtonMode.Primary}
           >
             <FlagIcon height={20} className="inline mr-2 " />
             New Entry

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,8 +1,8 @@
-import { LinkButton } from "~components/Button";
+import { Button, LinkButton } from "~components/Button";
 import { useRecentEvents } from "~utils/hooks/history";
 import { useEffect, useState } from "react";
 import { Dialog, DialogHeader, DialogBody } from "~components/Dialog";
-import { DialogMode } from "~components/constants";
+import { ButtonMode, DialogMode } from "~components/constants";
 import Markdown from "react-markdown";
 import pjson from "../../package.json";
 import "./markdown.css";
@@ -40,12 +40,13 @@ export const HomePage: React.FC = () => {
     <>
       <div>
         <aside className="text-right">
-          <button
-            className="bg-emerald-900 text-right ml-auto mt-4 py-1 px-3 rounded-md"
+          <Button
+            mode={ButtonMode.Primary}
+            className="text-right ml-auto w-max mt-4"
             onClick={() => setUpdateDialogOpen(true)}
           >
-            View Update Notes
-          </button>
+            Update Notes
+          </Button>
         </aside>
 
         <section className="max-w-full">

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -5,8 +5,8 @@ import { Button, IconButton, LinkButton } from "~components/Button";
 import {
   BookOpenIcon,
   ChevronDownIcon,
-  ChevronLeftIcon,
   XMarkIcon,
+  ChevronLeftIcon,
 } from "@heroicons/react/24/outline";
 import { twMerge } from "tailwind-merge";
 import { Spinner } from "~components/Spinner";
@@ -17,7 +17,7 @@ import {
   DialogCustomHeader,
   DialogHeader,
 } from "~components/Dialog";
-import { DialogMode } from "~components/constants";
+import { ButtonMode, DialogMode } from "~components/constants";
 import { ProgramAbbr } from "robotevents/out/endpoints/programs";
 import { Input, RulesSelect, Select } from "~components/Input";
 import { Rule, useRulesForProgram } from "~utils/hooks/rules";
@@ -123,7 +123,11 @@ const EventPicker: React.FC = () => {
           </section>
         </DialogBody>
       </Dialog>
-      <Button className={twMerge("flex-1")} onClick={onClick}>
+      <Button
+        mode={ButtonMode.None}
+        className={twMerge("flex-1")}
+        onClick={onClick}
+      >
         <div
           className="grid items-center gap-2"
           style={{ gridTemplateColumns: "1fr 1.25rem" }}
@@ -204,12 +208,10 @@ const Rules: React.FC = () => {
           </section>
         </DialogBody>
       </Dialog>
-      <Button
+      <IconButton
         onClick={() => setOpen(true)}
-        className="flex items-center aspect-square justify-center"
-      >
-        <BookOpenIcon height={24} />
-      </Button>
+        icon={<BookOpenIcon height={24} />}
+      />
     </>
   );
 };
@@ -225,9 +227,11 @@ export const AppShell: React.FC = () => {
     >
       <Toaster />
       <nav className="h-16 flex gap-4 max-w-full">
-        <Button onClick={() => navigate(-1)} className="bg-transparent p-0">
-          <ChevronLeftIcon height={24} />
-        </Button>
+        <IconButton
+          onClick={() => navigate(-1)}
+          icon={<ChevronLeftIcon height={24} />}
+          className="aspect-auto bg-transparent"
+        />
         <EventPicker />
         <Rules />
       </nav>


### PR DESCRIPTION
- Better active styles on buttons
- Fix new incident button on team
- Store recent rules by program (closes #46)
- Only show teams in the division in the teams tab. Only show teams that have a ranking in the current division (or for overall finals divisions in a match) 