### PR TITLE
UX Tweaks + Skills Page

### DIFF
--- a/public/updateNotes.md
+++ b/public/updateNotes.md
@@ -1,3 +1,9 @@
+### 6 Feb 2024
+
+- Added skills-only page for multi-division events to make it easier to enter incidents
+- Fix bug where incidents could not be created from the team page
+- Performance improvements and bug fixes
+
 ### 18 Jan 2024
 
 - You are now able to share your anomaly log with other users from the Manage tab of an event.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { EventTeamsPage } from "./pages/events/team";
 import { EventDivisionPickerPage } from "./pages/events/division";
 import { HomePage } from "./pages/home";
 import { EventJoinPage } from "pages/events/join";
+import { EventSkillsPage } from "pages/events/skills";
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route element={<AppShell />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/:sku">
+            <Route path="/:sku/skills/" element={<EventSkillsPage />} />
             <Route index path="/:sku" element={<EventDivisionPickerPage />} />
             <Route path="/:sku/:division" element={<EventPage />} />
             <Route path="/:sku/join" element={<EventJoinPage />} />

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -50,7 +50,10 @@ export const DialogBody: React.FC<DialogBodyProps> = ({
   return (
     <div
       {...props}
-      className={twMerge("flex-1 overflow-y-auto", props.className)}
+      className={twMerge(
+        "flex-1 overflow-y-auto overflow-x-clip max-w-full",
+        props.className
+      )}
     >
       {children}
     </div>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -87,6 +87,10 @@ export const Dialog: React.FC<DialogProps> = ({
     }
   }, [open, mode]);
 
+  if (!open) {
+    return null;
+  }
+
   return (
     <dialog
       {...props}

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -67,7 +67,7 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
     <details
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
-      className={twMerge("p-1 rounded-md mb-2")}
+      className="p-1 rounded-md mb-2 max-w-full"
     >
       <summary className="flex gap-2 items-center active:bg-zinc-700 rounded-md max-w-full">
         {open ? (
@@ -83,7 +83,7 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
         >
           <p>{number}</p>
         </div>
-        <ul className="text-sm flex-1 break-normal">
+        <ul className="text-sm flex-1 flex-shrink break-normal overflow-x-hidden">
           {rulesSummary.map(([rule, incidents]) => {
             let outcome: IncidentOutcome = "Minor";
             for (const incident of incidents) {

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -151,7 +151,7 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
       return false;
     }
     return !!team || !!event;
-  }, [preventSave, isLoadingMetaData, team]);
+  }, [preventSave, isLoadingMetaData, team, event]);
 
   const setIncidentField = <T extends keyof RichIncident>(
     key: T,
@@ -285,7 +285,7 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
         },
       });
     },
-    [incident, mutate, setOpen, addRecentRules]
+    [incident, mutate, setOpen, addRecentRules, initialMatch?.id]
   );
 
   return (

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -383,25 +383,29 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
               {rule.rule}
             </Button>
           ))}
-          <label className="flex-1">
-            <Select className="py-4" value={""} onChange={onPickOtherRule}>
-              <option>Pick Rule</option>
-              {rules?.ruleGroups.map((group) => (
-                <optgroup label={group.name} key={group.name}>
-                  {group.rules.map((rule) => (
-                    <option
-                      value={rule.rule}
-                      data-rulegroup={group.name}
-                      key={rule.rule}
-                    >
-                      {rule.rule} {rule.description}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </Select>
-          </label>
         </div>
+        <label>
+          <Select
+            className="py-4 max-w-full w-full mt-2"
+            value={""}
+            onChange={onPickOtherRule}
+          >
+            <option>Pick Rule</option>
+            {rules?.ruleGroups.map((group) => (
+              <optgroup label={group.name} key={group.name}>
+                {group.rules.map((rule) => (
+                  <option
+                    value={rule.rule}
+                    data-rulegroup={group.name}
+                    key={rule.rule}
+                  >
+                    {rule.rule} {rule.description}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </Select>
+        </label>
         <ul className="mt-4 flex flex-wrap gap-2">
           {incident.rules.map((rule) => (
             <li
@@ -428,14 +432,14 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
             onChange={onChangeIncidentNotes}
           />
         </label>
-        <Button
-          className="w-full text-center mt-4 bg-emerald-400 text-black"
-          disabled={!canSave}
-          onClick={onSubmit}
-        >
-          Submit
-        </Button>
       </DialogBody>
+      <Button
+        className="w-full text-center my-4 bg-emerald-400 text-black"
+        disabled={!canSave}
+        onClick={onSubmit}
+      >
+        Submit
+      </Button>
     </Dialog>
   );
 };

--- a/src/pages/events/division.tsx
+++ b/src/pages/events/division.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
 import { LinkButton } from "~components/Button";
+import { Spinner } from "~components/Spinner";
 import { useCurrentEvent } from "~hooks/state";
 
 export const EventDivisionPickerPage: React.FC = () => {
@@ -10,15 +11,20 @@ export const EventDivisionPickerPage: React.FC = () => {
     return <Navigate to={`/${event.sku}/${event.divisions[0].id}`} replace />;
   }
 
+  if (!event) {
+    return <Spinner show />;
+  }
+
   return (
     <section className="mt-4 flex flex-col gap-4">
-      {event?.divisions
+      {event.divisions
         .sort((a, b) => a.order - b.order)
         .map((division) => (
           <LinkButton to={`/${event.sku}/${division.id}`} key={division.id}>
             {division.name}
           </LinkButton>
         ))}
+      <LinkButton to={`/${event.sku}/skills`}>Skills</LinkButton>
     </section>
   );
 };

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -1,9 +1,9 @@
 import { useCurrentEvent } from "~utils/hooks/state";
 import { ShareProvider } from "./home";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAddEventVisited } from "~utils/hooks/history";
 import { Button } from "~components/Button";
-import { FlagIcon } from "@heroicons/react/20/solid";
+import { CodeBracketIcon, FlagIcon, PlayIcon } from "@heroicons/react/20/solid";
 import { EventNewIncidentDialog } from "./dialogs/new";
 import { Tabs } from "~components/Tabs";
 import { EventManageTab } from "./home/manage";
@@ -13,6 +13,7 @@ import { useEventSkills, useEventTeams } from "~utils/hooks/robotevents";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList as List } from "react-window";
 import { Link } from "react-router-dom";
+import { Skill } from "robotevents/out/endpoints/skills";
 
 type TeamSkillsTabProps = {
   event: EventData;
@@ -22,50 +23,90 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
   const { data: teams, isLoading: isLoadingTeams } = useEventTeams(event);
   const { data: skills, isLoading: isLoadingSkills } = useEventSkills(event);
 
+  const skillsByTeam = useMemo(() => {
+    if (!skills) {
+      return {};
+    }
+
+    const teams: Record<string, Skill[]> = {};
+
+    for (const skill of skills) {
+      if (teams[skill.team.name]) {
+        teams[skill.team.name].push(skill);
+      } else {
+        teams[skill.team.name] = [skill];
+      }
+    }
+
+    return teams;
+  }, [skills]);
+
   const isLoading = isLoadingTeams || isLoadingSkills;
 
-  console.log(skills);
-
   return (
-    <section className="flex-1">
-      <Spinner show={isLoading} />
-      <AutoSizer>
-        {(size) => (
-          <List
-            width={size.width}
-            height={size.height}
-            itemCount={teams?.length ?? 0}
-            itemSize={64}
-          >
-            {({ index, style }) => {
-              const team = teams?.[index];
+    <>
+      <section className="flex-1">
+        <Spinner show={isLoading} />
+        <AutoSizer>
+          {(size) => (
+            <List
+              width={size.width}
+              height={size.height}
+              itemCount={teams?.length ?? 0}
+              itemSize={64}
+            >
+              {({ index, style }) => {
+                const team = teams?.[index];
 
-              if (!team) {
-                return <div style={style} key={index}></div>;
-              }
+                if (!team) {
+                  return <div style={style} key={index}></div>;
+                }
 
-              return (
-                <div style={style} key={team.id}>
-                  <Link
-                    to={`/${event.sku}/team/${team.number}`}
-                    className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
-                  >
-                    <div className="flex-1">
-                      <p className="text-emerald-400 font-mono">
-                        {team.number}
+                const programming = skillsByTeam[team.number]?.find(
+                  (skill) => skill.type === "programming"
+                );
+
+                const driver = skillsByTeam[team.number]?.find(
+                  (skill) => skill.type === "driver"
+                );
+
+                return (
+                  <div style={style} key={team.id}>
+                    <Link
+                      to={`/${event.sku}/team/${team.number}`}
+                      className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
+                    >
+                      <div className="flex-1">
+                        <p className="text-emerald-400 font-mono">
+                          {team.number}
+                        </p>
+                        <p className="overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
+                          {team.team_name}
+                        </p>
+                      </div>
+                      <p className="h-full w-32 px-2 flex items-center">
+                        <span className="mr-4">
+                          <PlayIcon height={20} className="inline" />
+                          <span className="font-mono ml-2">
+                            {driver?.attempts ?? 0}
+                          </span>
+                        </span>
+                        <span className="">
+                          <CodeBracketIcon height={20} className="inline" />
+                          <span className="font-mono ml-2">
+                            {programming?.attempts ?? 0}
+                          </span>
+                        </span>
                       </p>
-                      <p className="overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
-                        {team.team_name}
-                      </p>
-                    </div>
-                  </Link>
-                </div>
-              );
-            }}
-          </List>
-        )}
-      </AutoSizer>
-    </section>
+                    </Link>
+                  </div>
+                );
+              }}
+            </List>
+          )}
+        </AutoSizer>
+      </section>
+    </>
   );
 };
 

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -1,0 +1,108 @@
+import { useCurrentEvent } from "~utils/hooks/state";
+import { ShareProvider } from "./home";
+import { useEffect, useState } from "react";
+import { useAddEventVisited } from "~utils/hooks/history";
+import { Button } from "~components/Button";
+import { FlagIcon } from "@heroicons/react/20/solid";
+import { EventNewIncidentDialog } from "./dialogs/new";
+import { Tabs } from "~components/Tabs";
+import { EventManageTab } from "./home/manage";
+import { Spinner } from "~components/Spinner";
+import { EventData } from "robotevents/out/endpoints/events";
+import { useEventSkills, useEventTeams } from "~utils/hooks/robotevents";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { FixedSizeList as List } from "react-window";
+import { Link } from "react-router-dom";
+
+type TeamSkillsTabProps = {
+  event: EventData;
+};
+
+const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
+  const { data: teams, isLoading: isLoadingTeams } = useEventTeams(event);
+  const { data: skills, isLoading: isLoadingSkills } = useEventSkills(event);
+
+  const isLoading = isLoadingTeams || isLoadingSkills;
+
+  console.log(skills);
+
+  return (
+    <section className="flex-1">
+      <Spinner show={isLoading} />
+      <AutoSizer>
+        {(size) => (
+          <List
+            width={size.width}
+            height={size.height}
+            itemCount={teams?.length ?? 0}
+            itemSize={64}
+          >
+            {({ index, style }) => {
+              const team = teams?.[index];
+
+              if (!team) {
+                return <div style={style} key={index}></div>;
+              }
+
+              return (
+                <div style={style} key={team.id}>
+                  <Link
+                    to={`/${event.sku}/team/${team.number}`}
+                    className="flex items-center gap-4 mt-4 h-12 text-zinc-50"
+                  >
+                    <div className="flex-1">
+                      <p className="text-emerald-400 font-mono">
+                        {team.number}
+                      </p>
+                      <p className="overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose">
+                        {team.team_name}
+                      </p>
+                    </div>
+                  </Link>
+                </div>
+              );
+            }}
+          </List>
+        )}
+      </AutoSizer>
+    </section>
+  );
+};
+
+export const EventSkillsPage: React.FC = () => {
+  const { data: event } = useCurrentEvent();
+
+  const [incidentDialogOpen, setIncidentDialogOpen] = useState(false);
+  const { mutateAsync: addEvent, isSuccess } = useAddEventVisited();
+
+  useEffect(() => {
+    if (event && !isSuccess) {
+      addEvent(event);
+    }
+  }, [event, isSuccess, addEvent]);
+
+  if (!event) {
+    return <Spinner show />;
+  }
+
+  return (
+    <ShareProvider>
+      <section className="mt-4 flex flex-col">
+        <Button onClick={() => setIncidentDialogOpen(true)} mode="primary">
+          <FlagIcon height={20} className="inline mr-2 " />
+          New Entry
+        </Button>
+        <EventNewIncidentDialog
+          open={incidentDialogOpen}
+          setOpen={setIncidentDialogOpen}
+        />
+        <Tabs className="flex-1">
+          {{
+            Teams: <TeamSkillsTab event={event} />,
+            Manage: <EventManageTab event={event} />,
+          }}
+        </Tabs>
+      </section>
+    </ShareProvider>
+  );
+};

--- a/src/pages/events/team.tsx
+++ b/src/pages/events/team.tsx
@@ -121,8 +121,8 @@ export const EventTeamsPage: React.FC = () => {
       <section>
         <Tabs>
           {{
-            Schedule: <EventTeamsMatches event={event} team={team} />,
             Incidents: <EventTeamsIncidents event={event} team={team} />,
+            Schedule: <EventTeamsMatches event={event} team={team} />,
           }}
         </Tabs>
       </section>

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
-import { Outlet, useNavigate } from "react-router-dom";
+import {
+  Outlet,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from "react-router-dom";
 import { useEvent, useEventsToday } from "~utils/hooks/robotevents";
 import { Button, IconButton, LinkButton } from "~components/Button";
 import {
@@ -28,6 +33,7 @@ function isValidSKU(sku: string) {
 const EventPicker: React.FC = () => {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [query, setQuery] = useState("");
   const { data: eventFromSKU, isLoading: isLoadingEventFromSKU } = useEvent(
@@ -62,7 +68,9 @@ const EventPicker: React.FC = () => {
   }, [query, eventsToday]);
 
   const selectedDiv = event?.divisions.find((d) => d.id === division);
-  const showDiv = selectedDiv && (event?.divisions.length ?? 0) > 1;
+  const showDiv =
+    location.pathname !== `/${event?.sku}` &&
+    (event?.divisions.length ?? 0) > 1;
 
   const onClick = () => {
     if (showDiv) {

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -1,10 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  Outlet,
-  useLocation,
-  useNavigate,
-  useResolvedPath,
-} from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useEvent, useEventsToday } from "~utils/hooks/robotevents";
 import { Button, IconButton, LinkButton } from "~components/Button";
 import {

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -243,7 +243,7 @@ export const AppShell: React.FC = () => {
       <Toaster />
       <nav className="h-16 flex gap-4 max-w-full">
         <IconButton
-          onClick={() => navigate(-1)}
+          onClick={() => navigate("/")}
           icon={<ChevronLeftIcon height={24} />}
           className="aspect-auto bg-transparent"
         />

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -27,10 +27,14 @@ export function useIncident(id: string | undefined | null) {
 export function useNewIncident() {
   return useMutation({
     mutationFn: async (incident: Incident) => {
-      const id = await newIncident(incident);
-      await queryClient.invalidateQueries({ queryKey: ["incidents"] });
-      return id;
+      // Catch failed fetch
+      try {
+        const id = await newIncident(incident);
+        await queryClient.invalidateQueries({ queryKey: ["incidents"] });
+        return id;
+      } catch { };
     },
+
   });
 }
 

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -54,7 +54,9 @@ export function useEventIncidents(sku: string | undefined | null) {
 export function useDeleteIncident(id: string, updateRemote?: boolean) {
   return useMutation<unknown, Error, unknown>({
     mutationFn: async () => {
-      await deleteIncident(id, updateRemote);
+      try {
+        await deleteIncident(id, updateRemote);
+      } catch { };
       await queryClient.invalidateQueries({ queryKey: ["incidents"] });
     },
   });

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -9,6 +9,7 @@ import {
 } from "../data/incident";
 import { UseQueryResult, useMutation, useQuery } from "@tanstack/react-query";
 import { Alliance, Match, MatchData } from "robotevents/out/endpoints/matches";
+import { toast } from "~components/Toast";
 import { queryClient } from "~utils/data/query";
 
 export function useIncident(id: string | undefined | null) {
@@ -32,9 +33,10 @@ export function useNewIncident() {
         const id = await newIncident(incident);
         await queryClient.invalidateQueries({ queryKey: ["incidents"] });
         return id;
-      } catch { };
+      } catch (e) {
+        toast({ type: "error", message: `${e}` });
+      }
     },
-
   });
 }
 
@@ -56,7 +58,9 @@ export function useDeleteIncident(id: string, updateRemote?: boolean) {
     mutationFn: async () => {
       try {
         await deleteIncident(id, updateRemote);
-      } catch { };
+      } catch (e) {
+        toast({ type: "error", message: `${e}` });
+      }
       await queryClient.invalidateQueries({ queryKey: ["incidents"] });
     },
   });

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -293,7 +293,11 @@ export function useEventsToday(
   });
 }
 
-export function useEventSkills(data: EventData | null | undefined, options?: SkillOptionsFromEvent, queryOptions?: HookQueryOptions<Skill[]>) {
+export function useEventSkills(
+  data: EventData | null | undefined,
+  options?: SkillOptionsFromEvent,
+  queryOptions?: HookQueryOptions<Skill[]>
+) {
   return useQuery({
     queryKey: ["skills", data?.sku, options],
     queryFn: async () => {
@@ -305,6 +309,6 @@ export function useEventSkills(data: EventData | null | undefined, options?: Ski
       const runs = await event.skills();
       return runs.array();
     },
-    ...queryOptions
+    ...queryOptions,
   });
-};
+}

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -17,6 +17,7 @@ import {
 } from "robotevents/out/endpoints/teams";
 import { EventData } from "robotevents/out/endpoints/events";
 import { useMemo } from "react";
+import { Skill, SkillOptionsFromEvent } from "robotevents/out/endpoints/skills";
 
 const ROBOTEVENTS_TOKEN =
   "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiIzIiwianRpIjoiYjM5Y2I1NGNhMTk0OTM0ODNmNTc0MDQ2MTRhZDY0MDZjYTY1ZmQzMjAzNDlhMmM5YmUwOThlNmJjNzhhZWJmZmZjYzU0ZWY2MTQ2ZmQyYjEiLCJpYXQiOjE2ODc2NDIzODcuNTUwMjg4LCJuYmYiOjE2ODc2NDIzODcuNTUwMjkxMSwiZXhwIjoyNjM0NDE3MTg3LjUzNzIzNjIsInN1YiI6Ijk3MDY5Iiwic2NvcGVzIjpbXX0.k0DEt3QRKkgZnyV8X9mDf6VYyc8aOsIEfQbVN4Gi6Csr7O5ILLGFENXZouvplqbcMDdQ8gBMMLg5hIR38RmrTsKcWHMndq1T8wYkGZQfRhc_uZYLQhGQCaanf_F_-gnKocFwT1AKQJmAPkAbV-Itb2UzHeGpNuW8vV_TaNL3coaYvmM6rubwBuNYgyZhTHW_Mgvzh5-XBqqGpmQLm9TGl4gkeqnS-6a5PfoqRTc8v3CQWSCURFry5BA2oXz0lcWmq92FY5crr2KKv1O3chPr--oMba97elY0y9Dw0q2ipKcTm4pE7bbFP8t7-a_RKU4OyXuHRIQXjw3gEDCYXY5Hp22KMY0idnRIPhat6fybxcRfeyzUzdnubRBkDMNklwlgNCyeu2ROqEOYegtu5727Wwvy2I-xW-ZVoXg0rggVu7jVq6zmBqDFIcu50IS9R4P6a244pg2STlBaAGpzT2VfUqCBZrbtBOvdmdNzxSKIkl1AXeOIZOixo1186PX54p92ehXfCbcTgWrQSLuAAg_tBa6T7UFKFOGecVFo3v0vkmE__Q5-701f1qqcdDRNlOG-bzzFh9QLEdJWlpEajwYQ1ZjTAlbnBpKy3IrU0Aa-Jr0aqxtzgr5ZlghNtOcdYYRw5_BN0BOMmAnkvtm0_xzIJSsFbWJQJ8QpPk_n4zKZf-Y";
@@ -291,3 +292,19 @@ export function useEventsToday(
     ...options,
   });
 }
+
+export function useEventSkills(data: EventData | null | undefined, options?: SkillOptionsFromEvent, queryOptions?: HookQueryOptions<Skill[]>) {
+  return useQuery({
+    queryKey: ["skills", data?.sku, options],
+    queryFn: async () => {
+      if (!data) {
+        return [];
+      }
+
+      const event = new robotevents.events.Event(data);
+      const runs = await event.skills();
+      return runs.array();
+    },
+    ...queryOptions
+  });
+};

--- a/src/utils/hooks/state.ts
+++ b/src/utils/hooks/state.ts
@@ -4,7 +4,7 @@ import { useEvent } from "./robotevents";
 export function useSKU() {
   const { sku } = useParams();
   return sku;
-};
+}
 
 export function useCurrentEvent() {
   const { sku } = useParams();

--- a/src/utils/hooks/state.ts
+++ b/src/utils/hooks/state.ts
@@ -1,6 +1,11 @@
 import { useParams } from "react-router-dom";
 import { useEvent } from "./robotevents";
 
+export function useSKU() {
+  const { sku } = useParams();
+  return sku;
+};
+
 export function useCurrentEvent() {
   const { sku } = useParams();
   return useEvent(sku ?? "");

--- a/worker/src/incidents.ts
+++ b/worker/src/incidents.ts
@@ -1,5 +1,5 @@
 import { Router } from "itty-router"
-import type { ShareUser, EventIncidents as EventIncidentsData, Incident, IncidentOutcome } from "../types/EventIncidents"
+import type { ShareUser, EventIncidents as EventIncidentsData, Incident } from "../types/EventIncidents"
 import { corsHeaders, response } from "./utils"
 import type { WebSocketMessage, WebSocketPayload, WebSocketPeerMessage, WebSocketSender, WebSocketServerShareInfoMessage } from "../types/api";
 
@@ -148,12 +148,6 @@ export class EventIncidents implements DurableObject {
     async handleCSV() {
         const incidents = await this.getAllIncidents();
 
-        const outcome: Record<IncidentOutcome, string> = {
-            [0]: "Minor",
-            [1]: "Major",
-            [2]: "Disabled"
-        };
-
         let output = "Date,Time,ID,SKU,Division,Match,Team,Outcome,Rules,Notes\n";
 
         output += incidents.map(incident => {
@@ -165,7 +159,7 @@ export class EventIncidents implements DurableObject {
                 incident.division,
                 incident.match?.name,
                 incident.team,
-                outcome[incident.outcome],
+                incident.outcome,
                 incident.rules.join(" "),
                 incident.notes
             ].join(",")


### PR DESCRIPTION
- Add Skills Page, visible from multi-division events that lets users easily create incidents for teams in skills
- Place incident list first in teams page
- Fix #58
- Limit with of rules summary to prevent overflow
- Always show div selector 