### PR TITLE
Edit Incidents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "referee-fyi",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "referee-fyi",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "@tanstack/query-async-storage-persister": "^5.17.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "referee-fyi",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/public/updateNotes.md
+++ b/public/updateNotes.md
@@ -1,9 +1,11 @@
 ### 7 Jan 2024
 
-- Editing incidents is now possible!
+- You can now edit incidents after you have created.
+
 - Add general notes to incidents, which do not count in rule summaries. General notes are intended
   for situations where the referee wants to note something about the team without it necessarily
   being a violation (ex: team was 2 minutes late for match, or team showed good sportsmanship)
+
 - Added skills-only page for multi-division events to make it easier to enter incidents
 - Fix bug where incidents could not be created from the team page
 - Performance improvements and bug fixes

--- a/public/updateNotes.md
+++ b/public/updateNotes.md
@@ -1,5 +1,6 @@
-### 6 Jan 2024
+### 7 Jan 2024
 
+- Editing incidents is now possible!
 - Add general notes to incidents, which do not count in rule summaries. General notes are intended
   for situations where the referee wants to note something about the team without it necessarily
   being a violation (ex: team was 2 minutes late for match, or team showed good sportsmanship)

--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -1,8 +1,9 @@
 import { twMerge } from "tailwind-merge";
 import { IncidentOutcome, IncidentWithID } from "~utils/data/incident";
 import { IconButton } from "./Button";
-import { TrashIcon } from "@heroicons/react/24/outline";
-import { useDeleteIncident } from "~utils/hooks/incident";
+import { EditIncidentDialog } from "./dialogs/edit";
+import { useState } from "react";
+import { PencilSquareIcon } from "@heroicons/react/20/solid";
 
 const IncidentOutcomeClasses: { [O in IncidentOutcome]: string } = {
   Minor: "bg-yellow-400 text-yellow-900",
@@ -16,9 +17,15 @@ export type IncidentProps = {
 } & React.HTMLProps<HTMLDivElement>;
 
 export const Incident: React.FC<IncidentProps> = ({ incident, ...props }) => {
-  const { mutate: onClickDelete } = useDeleteIncident(incident.id);
+  const [editIncidentOpen, setEditIncidentOpen] = useState(false);
+
   return (
     <>
+      <EditIncidentDialog
+        incident={incident}
+        open={editIncidentOpen}
+        setOpen={setEditIncidentOpen}
+      />
       <div
         {...props}
         className={twMerge(
@@ -45,9 +52,9 @@ export const Incident: React.FC<IncidentProps> = ({ incident, ...props }) => {
           </ul>
         </div>
         <IconButton
-          icon={<TrashIcon height={20} />}
+          icon={<PencilSquareIcon height={20} />}
           className="bg-transparent text-black/75"
-          onClick={onClickDelete}
+          onClick={() => setEditIncidentOpen(true)}
         />
       </div>
     </>

--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -23,6 +23,7 @@ export const Incident: React.FC<IncidentProps> = ({ incident, ...props }) => {
     <>
       <EditIncidentDialog
         incident={incident}
+        key={incident.revision?.count ?? -1}
         open={editIncidentOpen}
         setOpen={setEditIncidentOpen}
       />

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,6 +1,8 @@
 import { twMerge } from "tailwind-merge";
 import { Game, Rule } from "~utils/hooks/rules";
 import { useCallback } from "react";
+import { IconButton } from "./Button";
+import { TrashIcon } from "@heroicons/react/24/outline";
 
 export type InputBaseProps = React.HTMLProps<HTMLInputElement>;
 
@@ -107,5 +109,84 @@ export const RulesSelect: React.FC<RulesSelectProps> = ({
         </optgroup>
       ))}
     </Select>
+  );
+};
+
+export type RulesMultiSelectProps = {
+  game: Game;
+  value: Rule[];
+  onChange: (rules: Rule[]) => void;
+};
+
+export const RulesMultiSelect: React.FC<RulesMultiSelectProps> = ({
+  game,
+  value,
+  onChange,
+}) => {
+  const onPickOtherRule = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const group = e.target.selectedOptions[0].dataset.rulegroup;
+      if (!group) return;
+
+      const rule = game?.ruleGroups
+        .find((g) => g.name === group)
+        ?.rules.find((r) => r.rule === e.target.value);
+
+      if (!rule) return;
+      if (value.some((r) => r.rule === rule.rule)) return;
+      onChange([...value, rule]);
+    },
+    [game, value]
+  );
+
+  const onRemoveRule = useCallback(
+    (rule: Rule) => {
+      const rules = value.filter((r) => r.rule !== rule.rule);
+      onChange(rules);
+    },
+    [value]
+  );
+
+  return (
+    <>
+      <Select
+        className="max-w-full w-full mt-2"
+        value={""}
+        onChange={onPickOtherRule}
+      >
+        <option>Pick Rule</option>
+        {game?.ruleGroups.map((group) => (
+          <optgroup label={group.name} key={group.name}>
+            {group.rules.map((rule) => (
+              <option
+                value={rule.rule}
+                data-rulegroup={group.name}
+                key={rule.rule}
+              >
+                {rule.rule} {rule.description}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </Select>
+      <ul className="mt-4 flex flex-wrap gap-2">
+        {value.map((rule) => (
+          <li
+            key={rule.rule}
+            className="p-2 flex w-full items-center bg-zinc-800 rounded-md"
+          >
+            <p className="flex-1 mr-1">
+              <strong className="font-mono mr-2">{rule.rule}</strong>
+              <span>{rule.description}</span>
+            </p>
+            <IconButton
+              className="bg-transparent"
+              icon={<TrashIcon height={24} />}
+              onClick={() => onRemoveRule(rule)}
+            ></IconButton>
+          </li>
+        ))}
+      </ul>
+    </>
   );
 };

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useMemo, useState } from "react";
+import { MatchData } from "robotevents/out/endpoints/matches";
+import { Button } from "~components/Button";
+import { Dialog, DialogBody, DialogHeader } from "~components/Dialog";
+import { Input, RulesMultiSelect, Select, TextArea } from "~components/Input";
+import { toast } from "~components/Toast";
+import {
+  IncidentOutcome,
+  IncidentWithID,
+  editIncident,
+} from "~utils/data/incident";
+import { queryClient } from "~utils/data/query";
+import { useDeleteIncident } from "~utils/hooks/incident";
+import { useEventMatchesForTeam, useEventTeam } from "~utils/hooks/robotevents";
+import { Rule, useRulesForProgram } from "~utils/hooks/rules";
+import { useCurrentEvent } from "~utils/hooks/state";
+
+export type EditIncidentDialogProps = {
+  open: boolean;
+  setOpen: (value: boolean) => void;
+  incident: IncidentWithID;
+};
+
+export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
+  open,
+  setOpen,
+  incident: initialIncident,
+}) => {
+  const [incident, setIncident] = useState(initialIncident);
+  const { mutateAsync: deleteIncident } = useDeleteIncident(incident.id);
+
+  const { data: eventData } = useCurrentEvent();
+  const teamData = useEventTeam(eventData, incident.team);
+  const { data: teamMatches } = useEventMatchesForTeam(eventData, teamData);
+
+  const teamMatchesByDivision = useMemo(() => {
+    const divisions: Record<string, MatchData[]> = {};
+
+    if (!teamMatches) {
+      return [];
+    }
+
+    for (const match of teamMatches) {
+      if (divisions[match.division.name]) {
+        divisions[match.division.name].push(match);
+      } else {
+        divisions[match.division.name] = [match];
+      }
+    }
+
+    return Object.entries(divisions);
+  }, [teamMatches]);
+
+  const game = useRulesForProgram(eventData?.program.code ?? "VRC");
+
+  const onChangeIncidentMatch = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const [division, name] = e.target.value.split("@");
+      const match = teamMatches?.find((match) => {
+        return (
+          match.division.id === Number.parseInt(division) && match.name === name
+        );
+      });
+      setIncident((incident) => ({
+        ...incident,
+        division: Number.parseInt(division),
+        match: match ? { id: match.id, name: match.name } : undefined,
+      }));
+    },
+    []
+  );
+
+  const onChangeIncidentOutcome = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setIncident((incident) => ({
+        ...incident,
+        outcome: e.target.value as IncidentOutcome,
+      }));
+    },
+    []
+  );
+
+  const initialRichRules = useMemo(() => {
+    const gameRules = game?.ruleGroups.flatMap((group) => group.rules) ?? [];
+    return incident.rules.map(
+      (rule) => gameRules.find((r) => r.rule === rule)!
+    );
+  }, [initialIncident.rules]);
+
+  const [incidentRules, setIncidentRules] = useState(initialRichRules);
+
+  const onChangeIncidentRules = useCallback((rules: Rule[]) => {
+    setIncidentRules(rules);
+    setIncident((incident) => ({
+      ...incident,
+      rules: rules.map((r) => r.rule),
+    }));
+  }, []);
+
+  const onChangeIncidentNotes = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setIncident((incident) => ({ ...incident, notes: e.target.value }));
+    },
+    []
+  );
+
+  const onClickDelete = useCallback(async () => {
+    setOpen(false);
+    await deleteIncident();
+    toast({ type: "info", message: "Deleted Incident" });
+  }, []);
+
+  const onClickSave = useCallback(async () => {
+    setOpen(false);
+    try {
+      await editIncident(incident.id, incident);
+      toast({ type: "info", message: "Saved Incident" });
+    } catch (e) {
+      toast({ type: "error", message: `${e}` });
+    }
+    await queryClient.invalidateQueries({ queryKey: ["incidents"] });
+  }, [incident]);
+
+  return (
+    <Dialog mode="modal" onClose={() => setOpen(false)} open={open}>
+      <DialogHeader onClose={() => setOpen(false)} title="Edit Incident" />
+      <DialogBody className="p-4">
+        <label>
+          <p className="mt-4">Team</p>
+          <Input value={incident.team} readOnly className="w-full" />
+        </label>
+        <label>
+          <p className="mt-4">Match</p>
+          <Select
+            className="w-full"
+            onChange={onChangeIncidentMatch}
+            value={
+              incident.match
+                ? incident.division + "@" + incident.match.name
+                : undefined
+            }
+          >
+            {teamMatchesByDivision.map(([name, matches]) => {
+              return (
+                <optgroup key={name} label={name}>
+                  {matches.map((match) => (
+                    <option
+                      key={match.id}
+                      value={match.division.id + "@" + match.name}
+                    >
+                      {match.name}
+                    </option>
+                  ))}
+                </optgroup>
+              );
+            })}
+          </Select>
+        </label>
+        <label>
+          <p className="mt-4">Outcome</p>
+          <Select
+            value={incident.outcome}
+            onChange={onChangeIncidentOutcome}
+            className="max-w-full w-full"
+          >
+            <option value="General">General</option>
+            <option value="Minor">Minor</option>
+            <option value="Major">Major</option>
+            <option value="Disabled">Disabled</option>
+          </Select>
+        </label>
+        {game ? (
+          <label>
+            <p className="mt-4">Associated Rules</p>
+            <RulesMultiSelect
+              game={game}
+              value={incidentRules}
+              onChange={onChangeIncidentRules}
+            />
+          </label>
+        ) : null}
+        <label>
+          <p className="mt-4">Notes</p>
+          <TextArea
+            className="w-full mt-2 h-32"
+            value={incident.notes}
+            onChange={onChangeIncidentNotes}
+          />
+        </label>
+      </DialogBody>
+      <nav className="flex gap-4 p-2">
+        <Button mode="dangerous" onClick={onClickDelete}>
+          Delete Incident
+        </Button>
+        <Button mode="primary" onClick={onClickSave}>
+          Save Incident
+        </Button>
+      </nav>
+    </Dialog>
+  );
+};

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -140,6 +140,7 @@ export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
                 : undefined
             }
           >
+            <option value={undefined}>Non-Match</option>
             {teamMatchesByDivision.map(([name, matches]) => {
               return (
                 <optgroup key={name} label={name}>

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -124,7 +124,7 @@ export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
   return (
     <Dialog mode="modal" onClose={() => setOpen(false)} open={open}>
       <DialogHeader onClose={() => setOpen(false)} title="Edit Incident" />
-      <DialogBody className="p-4">
+      <DialogBody>
         <label>
           <p className="mt-4">Team</p>
           <Input value={incident.team} readOnly className="w-full" />

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -6,9 +6,9 @@ import {
   useEventMatchesForTeam,
 } from "~hooks/robotevents";
 import { Rule, useRulesForProgram } from "~utils/hooks/rules";
-import { Select, TextArea } from "~components/Input";
+import { RulesMultiSelect, Select, TextArea } from "~components/Input";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Button, IconButton } from "~components/Button";
+import { Button } from "~components/Button";
 import { MatchContext } from "~components/Context";
 import { useCurrentDivision, useCurrentEvent, useSKU } from "~hooks/state";
 import {
@@ -18,7 +18,6 @@ import {
 } from "~utils/data/incident";
 import { useNewIncident } from "~hooks/incident";
 import { Dialog, DialogBody, DialogHeader } from "~components/Dialog";
-import { TrashIcon } from "@heroicons/react/24/outline";
 import { useAddRecentRules, useRecentRules } from "~utils/hooks/history";
 import { twMerge } from "tailwind-merge";
 import { toast } from "~components/Toast";
@@ -239,21 +238,9 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
     [incident.rules, onAddRule, onRemoveRule]
   );
 
-  const onPickOtherRule = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      const group = e.target.selectedOptions[0].dataset.rulegroup;
-      if (!group) return;
-
-      const rule = rules?.ruleGroups
-        .find((g) => g.name === group)
-        ?.rules.find((r) => r.rule === e.target.value);
-
-      if (!rule) return;
-      if (incident.rules.some((r) => r.rule === rule.rule)) return;
-      setIncidentField("rules", [...incident.rules, rule]);
-    },
-    [rules, incident.rules]
-  );
+  const onChangeIncidentRules = useCallback((rules: Rule[]) => {
+    setIncidentField("rules", rules);
+  }, []);
 
   const onChangeIncidentNotes = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -368,64 +355,31 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
             <option value="Disabled">Disabled</option>
           </Select>
         </label>
-        <p className="mt-4">Associated Rules</p>
-        <div className="flex mt-2 gap-2 flex-wrap md:flex-nowrap">
-          {recentRules?.map((rule) => (
-            <Button
-              mode="none"
-              className={twMerge(
-                "text-emerald-400 font-mono min-w-min flex-shrink",
-                incident.rules.some((r) => r.rule === rule.rule)
-                  ? "bg-emerald-600 text-zinc-50"
-                  : ""
-              )}
-              onClick={() => onToggleRule(rule)}
-              key={rule.rule}
-            >
-              {rule.rule}
-            </Button>
-          ))}
-        </div>
         <label>
-          <Select
-            className="py-4 max-w-full w-full mt-2"
-            value={""}
-            onChange={onPickOtherRule}
-          >
-            <option>Pick Rule</option>
-            {rules?.ruleGroups.map((group) => (
-              <optgroup label={group.name} key={group.name}>
-                {group.rules.map((rule) => (
-                  <option
-                    value={rule.rule}
-                    data-rulegroup={group.name}
-                    key={rule.rule}
-                  >
-                    {rule.rule} {rule.description}
-                  </option>
-                ))}
-              </optgroup>
+          <p className="mt-4">Associated Rules</p>
+          <div className="flex mt-2 gap-2 flex-wrap md:flex-nowrap">
+            {recentRules?.map((rule) => (
+              <Button
+                mode="none"
+                className={twMerge(
+                  "text-emerald-400 font-mono min-w-min flex-shrink",
+                  incident.rules.some((r) => r.rule === rule.rule)
+                    ? "bg-emerald-600 text-zinc-50"
+                    : ""
+                )}
+                onClick={() => onToggleRule(rule)}
+                key={rule.rule}
+              >
+                {rule.rule}
+              </Button>
             ))}
-          </Select>
+          </div>
+          <RulesMultiSelect
+            game={rules!}
+            value={incident.rules}
+            onChange={onChangeIncidentRules}
+          />
         </label>
-        <ul className="mt-4 flex flex-wrap gap-2">
-          {incident.rules.map((rule) => (
-            <li
-              key={rule.rule}
-              className="p-2 flex w-full items-center bg-zinc-800 rounded-md"
-            >
-              <p className="flex-1 mr-1">
-                <strong className="font-mono mr-2">{rule.rule}</strong>
-                <span>{rule.description}</span>
-              </p>
-              <IconButton
-                className="bg-transparent"
-                icon={<TrashIcon height={24} />}
-                onClick={() => onRemoveRule(rule)}
-              ></IconButton>
-            </li>
-          ))}
-        </ul>
         <label>
           <p className="mt-4">Notes</p>
           <TextArea

--- a/src/pages/events/team.tsx
+++ b/src/pages/events/team.tsx
@@ -14,6 +14,7 @@ import { Incident } from "~components/Incident";
 import { EventNewIncidentDialog } from "./dialogs/new";
 import { Button } from "~components/Button";
 import { FlagIcon } from "@heroicons/react/20/solid";
+import { ShareProvider } from "./home";
 
 type EventTeamsTabProps = {
   event: EventData | null | undefined;
@@ -100,32 +101,34 @@ export const EventTeamsPage: React.FC = () => {
   }, [team]);
 
   return (
-    <section>
-      <EventNewIncidentDialog
-        open={incidentDialogOpen}
-        setOpen={setIncidentDialogOpen}
-        initialTeamNumber={number}
-      />
-      <header className="mt-4">
-        <Button onClick={() => setIncidentDialogOpen(true)} mode="primary">
-          <FlagIcon height={20} className="inline mr-2 " />
-          New Entry
-        </Button>
-        <h1 className="text-xl overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose mt-4">
-          <span className="font-mono text-emerald-400">{number}</span>
-          {" • "}
-          <span>{team?.team_name}</span>
-        </h1>
-        <p className="italic">{teamLocation}</p>
-      </header>
+    <ShareProvider>
       <section>
-        <Tabs>
-          {{
-            Incidents: <EventTeamsIncidents event={event} team={team} />,
-            Schedule: <EventTeamsMatches event={event} team={team} />,
-          }}
-        </Tabs>
+        <EventNewIncidentDialog
+          open={incidentDialogOpen}
+          setOpen={setIncidentDialogOpen}
+          initialTeamNumber={number}
+        />
+        <header className="mt-4">
+          <Button onClick={() => setIncidentDialogOpen(true)} mode="primary">
+            <FlagIcon height={20} className="inline mr-2 " />
+            New Entry
+          </Button>
+          <h1 className="text-xl overflow-hidden whitespace-nowrap text-ellipsis max-w-[20ch] lg:max-w-prose mt-4">
+            <span className="font-mono text-emerald-400">{number}</span>
+            {" • "}
+            <span>{team?.team_name}</span>
+          </h1>
+          <p className="italic">{teamLocation}</p>
+        </header>
+        <section>
+          <Tabs>
+            {{
+              Incidents: <EventTeamsIncidents event={event} team={team} />,
+              Schedule: <EventTeamsMatches event={event} team={team} />,
+            }}
+          </Tabs>
+        </section>
       </section>
-    </section>
+    </ShareProvider>
   );
 };

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -3,7 +3,7 @@ import { v1 as uuid } from "uuid";
 import { Rule } from "~hooks/rules";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { TeamData } from "robotevents/out/endpoints/teams";
-import { addServerIncident, deleteServerIncident } from "./share";
+import { addServerIncident, deleteServerIncident, editServerIncident } from "./share";
 import { IncidentOutcome, Incident as ServerIncident } from "~share/api";
 
 export type Incident = Omit<ServerIncident, "id">;
@@ -33,9 +33,9 @@ export function packIncident(incident: RichIncident): Incident {
     ...incident,
     match: incident.match
       ? {
-          id: incident.match.id,
-          name: incident.match.name,
-        }
+        id: incident.match.id,
+        name: incident.match.name,
+      }
       : undefined,
     team: incident.team?.number,
     rules: incident.rules.map((rule) => rule.rule),
@@ -124,6 +124,26 @@ export async function newIncident(
   }
 
   return id;
+}
+
+export async function editIncident(
+  id: string,
+  incident: Omit<IncidentWithID, "team" | "event">,
+  updateRemote: boolean = true
+) {
+  const current = await getIncident(id);
+
+  if (!current) {
+    return;
+  }
+
+  const updatedIncident = { ...current, ...incident };
+  await setIncident(id, updatedIncident);
+
+  if (updateRemote) {
+    await editServerIncident(updatedIncident)
+  };
+
 }
 
 export async function deleteIncident(

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -268,15 +268,18 @@ export class ShareConnection extends EventEmitter {
           const has = await hasIncident(data.incident.id);
           if (!has) {
             await newIncident(data.incident, false, data.incident.id);
+            queryClient.invalidateQueries({ queryKey: ["incidents"] });
           }
           break;
         }
         case "update_incident": {
           await setIncident(data.incident.id, data.incident);
+          queryClient.invalidateQueries({ queryKey: ["incidents"] });
           break;
         }
         case "remove_incident": {
           await deleteIncident(data.id, false);
+          queryClient.invalidateQueries({ queryKey: ["incidents"] });
           break;
         }
 

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -308,17 +308,20 @@ export class ShareConnection extends EventEmitter {
               const localRevision = current.revision?.count ?? 0;
               const remoteRevision = incident.revision?.count ?? 0;
 
-              console.log(incident, localRevision, remoteRevision)
-
               if (localRevision > remoteRevision) {
                 const response = await editServerIncident(current);
                 if (response?.success) {
                   current.revision = response.data;
                 }
                 await setIncident(incident.id, current);
-              } else if (remoteRevision > localRevision) {
-                await setIncident(incident.id, incident);
+                queryClient.invalidateQueries({ queryKey: ["incidents"] });
               }
+
+              if (remoteRevision > localRevision) {
+                await setIncident(incident.id, incident);
+                queryClient.invalidateQueries({ queryKey: ["incidents"] });
+              }
+
             }
           }
 

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -27,6 +27,10 @@ const URL_BASE = import.meta.env.DEV
   ? "http://localhost:8787"
   : "https://referee-fyi-share.bren.workers.dev";
 
+export async function getShareName() {
+  return (await get<string>("share_name")) ?? "";
+};
+
 export async function getShareData(sku: string, code: string) {
   const response = await fetch(
     new URL(`/api/share/${sku}/${code}/get`, URL_BASE)
@@ -301,8 +305,10 @@ export class ShareConnection extends EventEmitter {
             } else {
               const current = (await getIncident(incident.id))!;
 
-              const localRevision = incident.revision?.count ?? 0;
+              const localRevision = current.revision?.count ?? 0;
               const remoteRevision = incident.revision?.count ?? 0;
+
+              console.log(incident, localRevision, remoteRevision)
 
               if (localRevision > remoteRevision) {
                 const response = await editServerIncident(current);

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -54,7 +54,7 @@ export function useEventIncidents(sku: string | undefined | null) {
 }
 
 export function useDeleteIncident(id: string, updateRemote?: boolean) {
-  return useMutation<unknown, Error, unknown>({
+  return useMutation<unknown, Error, void>({
     mutationFn: async () => {
       try {
         await deleteIncident(id, updateRemote);

--- a/src/utils/hooks/share.ts
+++ b/src/utils/hooks/share.ts
@@ -14,7 +14,7 @@ import {
   WebSocketServerShareInfoMessage,
 } from "~share/api";
 import { queryClient } from "~utils/data/query";
-import { ShareConnection, createShare, getShareData } from "~utils/data/share";
+import { ShareConnection, createShare, getShareData, getShareName } from "~utils/data/share";
 
 export const connection = new ShareConnection();
 export const ShareContext = createContext(connection);
@@ -28,7 +28,7 @@ export function useShareName() {
 
   const query = useQuery({
     queryKey: ["share_name"],
-    queryFn: async () => (await get<string>("share_name")) ?? "",
+    queryFn: getShareName,
   });
 
   useEffect(() => {


### PR DESCRIPTION
Allows the users to edit incidents. This is done in a separate dialog, allowing you to edit the match, rules, outcome, and notes. We are not allowing editing of the team or event to prevent additional complexity with updating indices; the client should be able to receive revisions from the server and just immediately set that local value.

Note that most of the server-side groundwork for this came from #61. The sharing server is the entity that accepts and publishes updates to incidents that the client accepts. In the future, we could reject updates purely from the server if edit contention becomes a problem. 