### PR TITLE
Performance Improvements!

### DIFF
--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -4,13 +4,8 @@ import { Button } from "~components/Button";
 import { Dialog, DialogBody, DialogHeader } from "~components/Dialog";
 import { Input, RulesMultiSelect, Select, TextArea } from "~components/Input";
 import { toast } from "~components/Toast";
-import {
-  IncidentOutcome,
-  IncidentWithID,
-  editIncident,
-} from "~utils/data/incident";
-import { queryClient } from "~utils/data/query";
-import { useDeleteIncident } from "~utils/hooks/incident";
+import { IncidentOutcome, IncidentWithID } from "~utils/data/incident";
+import { useDeleteIncident, useEditIncident } from "~utils/hooks/incident";
 import { useEventMatchesForTeam, useEventTeam } from "~utils/hooks/robotevents";
 import { Rule, useRulesForProgram } from "~utils/hooks/rules";
 import { useCurrentEvent } from "~utils/hooks/state";
@@ -27,7 +22,8 @@ export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
   incident: initialIncident,
 }) => {
   const [incident, setIncident] = useState(initialIncident);
-  const { mutateAsync: deleteIncident } = useDeleteIncident(incident.id);
+  const { mutateAsync: deleteIncident } = useDeleteIncident();
+  const { mutateAsync: editIncident } = useEditIncident();
 
   const mostRecentUser = useMemo(() => {
     if (!incident.revision) {
@@ -121,19 +117,18 @@ export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
 
   const onClickDelete = useCallback(async () => {
     setOpen(false);
-    await deleteIncident();
+    await deleteIncident(incident.id);
     toast({ type: "info", message: "Deleted Incident" });
-  }, [deleteIncident, setOpen]);
+  }, [deleteIncident, setOpen, incident.id]);
 
   const onClickSave = useCallback(async () => {
     setOpen(false);
     try {
-      await editIncident(incident.id, incident);
+      await editIncident(incident);
       toast({ type: "info", message: "Saved Incident" });
     } catch (e) {
       toast({ type: "error", message: `${e}` });
     }
-    await queryClient.invalidateQueries({ queryKey: ["incidents"] });
   }, [incident, setOpen]);
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { initIncidentStore } from "./utils/data/incident";
-import { CACHE_BUSTER, queryClient, persister } from "~utils/data/query";
+import { queryClient } from "~utils/data/query";
 import { registerSW } from "virtual:pwa-register";
 import { initHistoryStore } from "~utils/hooks/history";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 registerSW({ immediate: true });
 
@@ -15,11 +15,8 @@ initHistoryStore();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <PersistQueryClientProvider
-      client={queryClient}
-      persistOptions={{ persister, buster: CACHE_BUSTER }}
-    >
+    <QueryClientProvider client={queryClient}>
       <App />
-    </PersistQueryClientProvider>
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/utils/data/query.ts
+++ b/src/utils/data/query.ts
@@ -1,33 +1,27 @@
 import { QueryClient } from "@tanstack/react-query";
-import { del, get, set } from "idb-keyval";
 import {
-  PersistedClient,
-  Persister,
+  PersistedQuery,
+  experimental_createPersister,
 } from "@tanstack/react-query-persist-client";
-
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      networkMode: "offlineFirst",
-      gcTime: 1000 * 60 * 60 * 24 * 7,
-    },
-  },
-});
+import { del, get, set } from "idb-keyval";
 
 // Cache buster key, used to forcibly invalidate queries
 export const CACHE_BUSTER = "v4";
 
-export function createIDBPersister(idbValidKey: IDBValidKey = "reactQuery") {
-  return {
-    persistClient: async (client: PersistedClient) => {
-      await set(idbValidKey, client);
-    },
-    restoreClient: async () => {
-      return await get<PersistedClient>(idbValidKey);
-    },
-    removeClient: async () => {
-      await del(idbValidKey);
-    },
-  } as Persister;
-}
-export const persister = createIDBPersister();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 1000 * 30,
+      persister: experimental_createPersister<PersistedQuery>({
+        buster: CACHE_BUSTER,
+        serialize: (query) => query,
+        deserialize: query => query,
+        storage: {
+          getItem: get,
+          setItem: set,
+          removeItem: del
+        }
+      })
+    }
+  },
+});


### PR DESCRIPTION
Two performance improvements here: 

1. Use a smarter persister that only writes the changes of `useQuery` when persisting instead of the entire client state. This should lead to significant performance improvements on most user actions.
2. Optimistic updates in the match dialog so that we don't need to wait for network requests to complete before updating the UI. This should have a significant perceptual performance improvement in the match dialog, the primary area where this matters. 