### PR TITLE
Split out event and team indices into their own keys

### DIFF
--- a/src/migrations/2024_05_17_splitIndex.ts
+++ b/src/migrations/2024_05_17_splitIndex.ts
@@ -1,0 +1,17 @@
+import { getAllIncidents, repairIndices } from "~utils/data/incident";
+import { queueMigration } from "./utils";
+
+queueMigration({
+  name: `2024_05_17_splitIndex`,
+  run_order: 1,
+  dependencies: ["2024_05_07_matchSkills"],
+  apply: async () => {
+    const incidents = await getAllIncidents();
+
+    for (const incident of incidents) {
+      await repairIndices(incident.id, incident);
+    }
+
+    return { success: true };
+  },
+});

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,3 +1,4 @@
 import "./2024_05_07_matchSkills";
+import "./2024_05_17_splitIndex";
 
 export { runMigrations } from "./utils";

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -1,4 +1,4 @@
-import { get, set } from "idb-keyval";
+import { get, getMany, set, setMany } from "idb-keyval";
 import { v1 as uuid } from "uuid";
 import { Rule } from "~hooks/rules";
 import { MatchData } from "robotevents/out/endpoints/matches";
@@ -21,10 +21,6 @@ import {
 export type Incident = Omit<ServerIncident, "id">;
 export type IncidentWithID = ServerIncident;
 export type { IncidentOutcome };
-
-export type IncidentIndex = {
-  [key: string]: string[];
-};
 
 export type RichIncidentElements = {
   time: Date;
@@ -69,18 +65,6 @@ export async function initIncidentStore() {
   if (!incidents) {
     await set("incidents", []);
   }
-
-  // Index by event
-  const eventsIndex = await get<IncidentIndex>("event_idx");
-  if (!eventsIndex) {
-    await set("event_idx", {});
-  }
-
-  // Index by team
-  const teamsIndex = await get<IncidentIndex>("team_idx");
-  if (!teamsIndex) {
-    await set("team_idx", {});
-  }
 }
 
 export async function getIncident(
@@ -98,25 +82,78 @@ export async function getIncident(
   };
 }
 
+export async function getManyIncidents(
+  ids: string[]
+): Promise<(IncidentWithID | undefined)[]> {
+  return (await getMany<Incident>(ids)).map((v, i) =>
+    v ? { id: ids[i], ...v } : undefined
+  );
+}
+
+export type IncidentIndices = {
+  event: string[];
+  team: string[];
+};
+
+export async function getIncidentIndices(
+  incident: Incident
+): Promise<IncidentIndices> {
+  const [event, team] = await getMany<string[] | undefined>([
+    `event_${incident.event}_idx`,
+    `team_${incident.team}_idx`,
+  ]);
+
+  return { event: event ?? [], team: team ?? [] };
+}
+
+export async function setIncidentIndices(
+  incident: Incident,
+  indices: IncidentIndices
+) {
+  return setMany([
+    [`event_${incident.event}_idx`, indices.event],
+    [`team_${incident.team}_idx`, indices.team],
+  ]);
+}
+
+export async function getDeletedIncidentIndices(
+  incident: Incident
+): Promise<IncidentIndices> {
+  const [event, team] = await getMany<string[] | undefined>([
+    `deleted_event_${incident.event}_idx`,
+    `deleted_team_${incident.team}_idx`,
+  ]);
+
+  return { event: event ?? [], team: team ?? [] };
+}
+
+export async function setDeletedIncidentIndices(
+  incident: Incident,
+  indices: IncidentIndices
+) {
+  return setMany([
+    [`deleted_event_${incident.event}_idx`, indices.event],
+    [`deleted_team_${incident.team}_idx`, indices.team],
+  ]);
+}
+
 export async function repairIndices(id: string, incident: Incident) {
-  const eventsIndex = await get<IncidentIndex>("event_idx");
-  const teamsIndex = await get<IncidentIndex>("team_idx");
+  const { event, team } = await getIncidentIndices(incident);
 
-  const eventIndex = eventsIndex?.[incident.event] ?? [];
-  const teamIndex = teamsIndex?.[incident.team ?? ""] ?? [];
+  let dirty = false;
 
-  if (!eventIndex.includes(id)) {
-    await set("event_idx", {
-      ...eventsIndex,
-      [incident.event]: [...eventIndex, id],
-    });
+  if (!event.includes(id)) {
+    event.push(id);
+    dirty = true;
   }
 
-  if (!teamIndex.includes(id)) {
-    await set("team_idx", {
-      ...teamsIndex,
-      [incident.team ?? ""]: [...teamIndex, id],
-    });
+  if (!team.includes(id)) {
+    team.push(id);
+    dirty = true;
+  }
+
+  if (dirty) {
+    return setIncidentIndices(incident, { event, team });
   }
 }
 
@@ -144,21 +181,15 @@ export async function newIncident(
 ): Promise<string> {
   await setIncident(id, incident);
 
-  // Add to all indices
-  const eventsIndex = await get<IncidentIndex>("event_idx");
-  const teamsIndex = await get<IncidentIndex>("team_idx");
+  // Index Properly
+  const { event, team } = await getIncidentIndices(incident);
 
-  const eventIndex = eventsIndex?.[incident.event] ?? [];
-  const teamIndex = teamsIndex?.[incident.team ?? ""] ?? [];
+  event.push(id);
+  team.push(id);
 
-  await set("event_idx", {
-    ...eventsIndex,
-    [incident.event]: [...eventIndex, id],
-  });
-
-  await set("team_idx", {
-    ...teamsIndex,
-    [incident.team ?? ""]: [...teamIndex, id],
+  setIncidentIndices(incident, {
+    event,
+    team,
   });
 
   const all = (await get<string[]>("incidents")) ?? [];
@@ -231,26 +262,23 @@ export async function deleteIncident(
     return;
   }
 
-  // Remove from all indices. Note that we're not *actually* deleted in the incidents, just removed
-  // from indices, so we could recover them in the future.
-  const eventsIndex = await get<IncidentIndex>("event_idx");
-  const teamsIndex = await get<IncidentIndex>("team_idx");
+  const { team, event } = await getIncidentIndices(incident);
 
-  const eventIndex = eventsIndex?.[incident.event] ?? [];
-  const teamIndex = teamsIndex?.[incident.team ?? ""] ?? [];
-
-  await set("event_idx", {
-    ...eventsIndex,
-    [incident.event]: eventIndex.filter((i) => i !== id),
+  await setIncidentIndices(incident, {
+    event: event.filter((i) => i !== id),
+    team: team.filter((i) => i !== id),
   });
 
-  await set("team_idx", {
-    ...teamsIndex,
-    [incident.team ?? ""]: teamIndex.filter((i) => i !== id),
-  });
+  const { event: deletedEvent, team: deletedTeam } =
+    await getDeletedIncidentIndices(incident);
 
-  const all = await get<string[]>("incidents");
-  await set("incidents", all?.filter((i) => i !== id) ?? []);
+  deletedEvent.push(id);
+  deletedTeam.push(id);
+
+  await setDeletedIncidentIndices(incident, {
+    event: deletedEvent,
+    team: deletedTeam,
+  });
 
   if (updateRemote) {
     await deleteServerIncident(id, incident.event);
@@ -258,30 +286,31 @@ export async function deleteIncident(
 }
 
 export async function getAllIncidents(): Promise<IncidentWithID[]> {
-  const all = await get<string[]>("incidents");
-  return Promise.all(
-    all?.map((id) => getIncident(id) as Promise<IncidentWithID>) ?? []
-  );
+  const ids = await get<string[]>(`incidents`);
+  if (!ids) return [];
+  const incidents = await getManyIncidents(ids);
+
+  return incidents.filter((i) => !!i);
 }
 
 export async function getIncidentsByEvent(
   event: string
 ): Promise<IncidentWithID[]> {
-  const eventsIndex = await get<IncidentIndex>("event_idx");
-  const ids = eventsIndex?.[event] ?? [];
-  return Promise.all(
-    ids.map((id) => getIncident(id) as Promise<IncidentWithID>)
-  );
+  const ids = await get<string[]>(`event_${event}_idx`);
+  if (!ids) return [];
+  const incidents = await getManyIncidents(ids);
+
+  return incidents.filter((i) => !!i);
 }
 
 export async function getIncidentsByTeam(
   team: string
 ): Promise<IncidentWithID[]> {
-  const teamsIndex = await get<IncidentIndex>("team_idx");
-  const ids = teamsIndex?.[team] ?? [];
-  return Promise.all(
-    ids.map((id) => getIncident(id) as Promise<IncidentWithID>)
-  );
+  const ids = await get<string[]>(`team_${team}_idx`);
+  if (!ids) return [];
+  const incidents = await getManyIncidents(ids);
+
+  return incidents.filter((i) => !!i);
 }
 
 export function matchToString(match: IncidentMatch) {


### PR DESCRIPTION
An internal data model change to split out event and team indices into separate keys. This should hopefully have a minor performance benefit, be slightly more scalable, and reduce the potential for index loss. 

Incidentally, I also added duration recording to migrations. This leads to a "Report Issue" dialog in the settings menu that users can use when something isn't working as expected. This should put a big context file into Cloudflare R2 storage, give you an issue number, and send an email or something.