### PR TITLE
Add "Scratchpad" to Record AWP and Auto in Over Under and High Stakes Games

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "referee-fyi",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "referee-fyi",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "@tanstack/query-async-storage-persister": "^5.17.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "prettier": "^3.1.0",
         "rollup": "^4.9.1",
         "tailwindcss": "^3.4.3",
-        "typescript": "^5.2.2",
+        "typescript": "^5.5.3",
         "vite": "^5.0.5",
         "vite-plugin-node-polyfills": "^0.16.0",
         "vite-plugin-pwa": "^0.17.2",
@@ -10426,9 +10426,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prettier": "^3.1.0",
     "rollup": "^4.9.1",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.2.2",
+    "typescript": "^5.5.3",
     "vite": "^5.0.5",
     "vite-plugin-node-polyfills": "^0.16.0",
     "vite-plugin-pwa": "^0.17.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "referee-fyi",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/public/updateNotes.md
+++ b/public/updateNotes.md
@@ -1,3 +1,7 @@
+## 15 July 2024
+- Improved sync performance and correctness when connecting to a share instance.
+- Added Scratchpad for High Stakes matches to record Auto Winner and AWP
+
 ### 21 May 2024
 
 - Added support for 2024/25 game rules (V5RC, VURC, and VIQRC).

--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -1,7 +1,7 @@
 import { twMerge } from "tailwind-merge";
 import {
   IncidentOutcome,
-  IncidentWithID,
+  Incident as IncidentData,
   matchToString,
 } from "~utils/data/incident";
 import { IconButton } from "./Button";
@@ -17,7 +17,7 @@ const IncidentOutcomeClasses: { [O in IncidentOutcome]: string } = {
 };
 
 export type IncidentProps = {
-  incident: IncidentWithID;
+  incident: IncidentData;
   readonly?: boolean;
 } & React.HTMLProps<HTMLDivElement>;
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,12 +1,12 @@
 import { twMerge } from "tailwind-merge";
 import { Game, Rule } from "~utils/hooks/rules";
-import React, { useCallback, useMemo } from "react";
+import React, { Dispatch, useCallback, useMemo } from "react";
 import { IconButton } from "./Button";
 import { TrashIcon } from "@heroicons/react/24/outline";
 
 export type CheckboxBinding = {
   value: boolean;
-  onChange: React.Dispatch<React.SetStateAction<boolean>>;
+  onChange: Dispatch<boolean>;
 };
 
 export type CheckboxProps = React.HTMLProps<HTMLInputElement> & {
@@ -53,7 +53,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
 export type RadioBinding<T> = {
   variant: T;
   value: T;
-  onChange: React.Dispatch<React.SetStateAction<T>>;
+  onChange: Dispatch<T>;
 };
 
 export type RadioProps<T extends string | number | symbol> =
@@ -102,7 +102,7 @@ export type InputBaseProps = React.HTMLProps<HTMLInputElement>;
 
 export type InputBiding = {
   value: string;
-  onChange: React.Dispatch<React.SetStateAction<string>>;
+  onChange: Dispatch<string>;
 };
 
 export type InputProps = InputBaseProps & { bind?: InputBiding };

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -4,15 +4,32 @@ import React, { useCallback, useMemo } from "react";
 import { IconButton } from "./Button";
 import { TrashIcon } from "@heroicons/react/24/outline";
 
+export type CheckboxBinding = {
+  value: boolean;
+  onChange: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
 export type CheckboxProps = React.HTMLProps<HTMLInputElement> & {
   label: string;
   labelProps?: React.HTMLProps<HTMLLabelElement>;
+  bind?: CheckboxBinding;
 };
 export const Checkbox: React.FC<CheckboxProps> = ({
   label,
   labelProps,
+  bind,
   ...props
 }) => {
+  const bindProps: React.HTMLProps<HTMLInputElement> = bind
+    ? {
+        checked: bind.value,
+        onChange: (e) => {
+          bind.onChange(e.currentTarget.checked);
+          props.onChange?.(e);
+        },
+      }
+    : {};
+
   return (
     <label
       {...labelProps}
@@ -24,6 +41,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
     >
       <input
         {...props}
+        {...bindProps}
         type="checkbox"
         className={twMerge("accent-emerald-400", props.className)}
       />
@@ -32,16 +50,34 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   );
 };
 
-export type RadioProps = React.HTMLProps<HTMLInputElement> & {
-  label: string;
-  labelProps?: React.HTMLProps<HTMLLabelElement>;
+export type RadioBinding<T> = {
+  variant: T;
+  value: T;
+  onChange: React.Dispatch<React.SetStateAction<T>>;
 };
 
-export const Radio: React.FC<RadioProps> = ({
+export type RadioProps<T extends string | number | symbol> =
+  React.HTMLProps<HTMLInputElement> & {
+    label: string;
+    labelProps?: React.HTMLProps<HTMLLabelElement>;
+    bind?: RadioBinding<T>;
+  };
+
+export const Radio = <T extends string | number | symbol>({
   labelProps,
   label,
+  bind,
   ...props
-}) => {
+}: RadioProps<T>) => {
+  const bindProps: React.HTMLProps<HTMLInputElement> = bind
+    ? {
+        checked: bind.value === bind.variant,
+        onChange: (e) => {
+          bind.onChange(bind.variant);
+          props.onChange?.(e);
+        },
+      }
+    : {};
   return (
     <label
       {...labelProps}
@@ -53,6 +89,7 @@ export const Radio: React.FC<RadioProps> = ({
     >
       <input
         {...props}
+        {...bindProps}
         type="radio"
         className={twMerge("accent-emerald-400", props.className)}
       />
@@ -63,12 +100,27 @@ export const Radio: React.FC<RadioProps> = ({
 
 export type InputBaseProps = React.HTMLProps<HTMLInputElement>;
 
-export type InputProps = InputBaseProps;
+export type InputBiding = {
+  value: string;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
+};
 
-export const Input: React.FC<InputProps> = (props) => {
+export type InputProps = InputBaseProps & { bind?: InputBiding };
+
+export const Input: React.FC<InputProps> = ({ bind, ...props }) => {
+  const bindProps: React.HTMLProps<HTMLInputElement> = bind
+    ? {
+        value: bind.value,
+        onChange: (e) => {
+          bind.onChange(bind.value);
+          props.onChange?.(e);
+        },
+      }
+    : {};
   return (
     <input
       {...props}
+      {...bindProps}
       className={twMerge(
         "rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2",
         "hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-500",

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -34,7 +34,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
     <label
       {...labelProps}
       className={twMerge(
-        "flex mt-4 gap-2 bg-zinc-700 p-2 rounded-md",
+        "flex mt-4 gap-2 bg-zinc-700 p-2 rounded-md items-center",
         "has-[:checked]:bg-emerald-800",
         labelProps?.className
       )}
@@ -82,7 +82,7 @@ export const Radio = <T extends string | number | symbol>({
     <label
       {...labelProps}
       className={twMerge(
-        `bg-zinc-700 rounded-md p-2 flex gap-2 justify-center`,
+        `bg-zinc-700 rounded-md p-2 flex gap-2 items-center`,
         "has-[:checked]:bg-emerald-800",
         labelProps?.className
       )}

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -10,7 +10,12 @@ import {
   TextArea,
 } from "~components/Input";
 import { toast } from "~components/Toast";
-import { IncidentMatchSkills, Revision, WebSocketSender } from "~share/api";
+import {
+  IncidentMatchSkills,
+  UnchangeableProperties,
+  WebSocketSender,
+} from "~share/api";
+import { Change } from "~share/revision";
 import {
   IncidentOutcome,
   IncidentWithID,
@@ -61,9 +66,9 @@ function timeAgo(input: Date) {
   return formatter.format(-1, "seconds");
 }
 
-export const RevisionEntry: React.FC<{ revision: Revision }> = ({
-  revision,
-}) => {
+export const RevisionEntry: React.FC<{
+  revision: Change<IncidentWithID, UnchangeableProperties>;
+}> = ({ revision }) => {
   const values: [ReactNode, ReactNode] = useMemo(() => {
     switch (revision.property) {
       case "time": {

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -16,11 +16,7 @@ import {
   WebSocketSender,
 } from "~share/api";
 import { Change } from "~share/revision";
-import {
-  IncidentOutcome,
-  IncidentWithID,
-  matchToString,
-} from "~utils/data/incident";
+import { IncidentOutcome, Incident, matchToString } from "~utils/data/incident";
 import { useDeleteIncident, useEditIncident } from "~utils/hooks/incident";
 import { useEventMatchesForTeam, useEventTeam } from "~utils/hooks/robotevents";
 import { Rule, useRulesForEvent } from "~utils/hooks/rules";
@@ -67,7 +63,7 @@ function timeAgo(input: Date) {
 }
 
 export const RevisionEntry: React.FC<{
-  revision: Change<IncidentWithID, UnchangeableProperties>;
+  revision: Change<Incident, UnchangeableProperties>;
 }> = ({ revision }) => {
   const values: [ReactNode, ReactNode] = useMemo(() => {
     switch (revision.property) {
@@ -99,7 +95,7 @@ export const RevisionEntry: React.FC<{
 };
 
 export type RevisionListProps = {
-  incident: IncidentWithID;
+  incident: Incident;
 };
 
 export const RevisionList: React.FC<RevisionListProps> = ({ incident }) => {
@@ -144,7 +140,7 @@ export const RevisionList: React.FC<RevisionListProps> = ({ incident }) => {
 export type EditIncidentDialogProps = {
   open: boolean;
   setOpen: (value: boolean) => void;
-  incident: IncidentWithID;
+  incident: Incident;
 };
 
 export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -22,31 +22,7 @@ import { useDeleteIncident, useEditIncident } from "~utils/hooks/incident";
 import { useEventMatchesForTeam, useEventTeam } from "~utils/hooks/robotevents";
 import { Rule, useRulesForEvent } from "~utils/hooks/rules";
 import { useCurrentEvent } from "~utils/hooks/state";
-
-function timeAgo(input: Date) {
-  const date = new Date(input);
-  const formatter = new Intl.RelativeTimeFormat("en");
-  const ranges = {
-    years: 3600 * 24 * 365,
-    months: 3600 * 24 * 30,
-    weeks: 3600 * 24 * 7,
-    days: 3600 * 24,
-    hours: 3600,
-    minutes: 60,
-    seconds: 1,
-  };
-  const secondsElapsed = (date.getTime() - Date.now()) / 1000;
-  for (const [key, value] of Object.entries(ranges)) {
-    if (value < Math.abs(secondsElapsed)) {
-      const delta = secondsElapsed / value;
-      return formatter.format(
-        Math.round(delta),
-        key as Intl.RelativeTimeFormatUnit
-      );
-    }
-  }
-  return formatter.format(-1, "seconds");
-}
+import { timeAgo } from "~utils/time";
 
 export const RevisionEntry: React.FC<{
   revision: Change<Incident, UnchangeableProperties>;

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -10,32 +10,18 @@ import {
   TextArea,
 } from "~components/Input";
 import { toast } from "~components/Toast";
-import {
-  IncidentMatchSkills,
-  UnchangeableProperties,
-  WebSocketSender,
-} from "~share/api";
+import { IncidentMatchSkills, UnchangeableProperties } from "~share/api";
 import { Change } from "~share/revision";
-import { IncidentOutcome, Incident, matchToString } from "~utils/data/incident";
+import {
+  IncidentOutcome,
+  Incident,
+  matchToString,
+  userString,
+} from "~utils/data/incident";
 import { useDeleteIncident, useEditIncident } from "~utils/hooks/incident";
 import { useEventMatchesForTeam, useEventTeam } from "~utils/hooks/robotevents";
 import { Rule, useRulesForEvent } from "~utils/hooks/rules";
 import { useCurrentEvent } from "~utils/hooks/state";
-
-function userString(user?: WebSocketSender) {
-  if (!user) {
-    return null;
-  }
-
-  switch (user.type) {
-    case "server": {
-      return "Server";
-    }
-    case "client": {
-      return user.name;
-    }
-  }
-}
 
 function timeAgo(input: Date) {
   const date = new Date(input);

--- a/src/components/scratchpad/HighStakes.tsx
+++ b/src/components/scratchpad/HighStakes.tsx
@@ -1,7 +1,5 @@
-import { ClockIcon } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
 import { MatchData } from "robotevents/out/endpoints/matches";
-import { IconButton } from "~components/Button";
 import { Checkbox, Radio } from "~components/Input";
 import { HighStakesMatchScratchpad } from "~share/MatchScratchpad";
 import { setMatchScratchpad } from "~utils/data/scratchpad";

--- a/src/components/scratchpad/HighStakes.tsx
+++ b/src/components/scratchpad/HighStakes.tsx
@@ -93,7 +93,7 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
             }}
             className="accent-red-400"
             labelProps={{
-              className: "has-[:checked]:bg-red-800 mt-0 flex-1 px-4",
+              className: "has-[:checked]:bg-red-800 mt-0 flex-1 px-2",
             }}
           />
           <Radio
@@ -106,7 +106,7 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
             }}
             className="accent-blue-400"
             labelProps={{
-              className: "has-[:checked]:bg-blue-800 mt-0 flex-1 px-4",
+              className: "has-[:checked]:bg-blue-800 mt-0 flex-1 px-2",
             }}
           />
           <Radio
@@ -119,7 +119,7 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
               variant: "tie",
             }}
             labelProps={{
-              className: "has-[:checked]:bg-purple-800 mt-0 flex-1 px-4",
+              className: "has-[:checked]:bg-purple-800 mt-0 flex-1 px-2",
             }}
           />
           <Radio
@@ -130,7 +130,7 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
               onChange: setAutoWinner,
               variant: "none",
             }}
-            labelProps={{ className: "mt-0 flex-1 px-4" }}
+            labelProps={{ className: "mt-0 flex-1 px-2" }}
           />
         </fieldset>
       </section>

--- a/src/components/scratchpad/HighStakes.tsx
+++ b/src/components/scratchpad/HighStakes.tsx
@@ -1,13 +1,17 @@
+import { CodeBracketSquareIcon, StarIcon } from "@heroicons/react/20/solid";
 import { useEffect, useState } from "react";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { Checkbox, Radio } from "~components/Input";
 import { HighStakesMatchScratchpad } from "~share/MatchScratchpad";
-import { setMatchScratchpad } from "~utils/data/scratchpad";
+import { userString } from "~utils/data/incident";
+import { getScratchpadID, setMatchScratchpad } from "~utils/data/scratchpad";
 import {
   useDefaultScratchpad,
   useMatchScratchpad,
+  usePropertyLastChangeLogForScratchpad,
   useUpdateMatchScratchpad,
 } from "~utils/hooks/scratchpad";
+import { timeAgo } from "~utils/time";
 
 export type HighStakesScratchpadProps = {
   match: MatchData;
@@ -21,6 +25,8 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
   const { data } = useMatchScratchpad<HighStakesMatchScratchpad>(match);
   const { mutateAsync: updateScratchpad } =
     useUpdateMatchScratchpad<HighStakesMatchScratchpad>(match);
+
+  const changeLog = usePropertyLastChangeLogForScratchpad(data);
 
   const [autoWinner, setAutoWinner] = useState(
     data ? data.auto : fallback?.auto ?? "none"
@@ -36,10 +42,12 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
   // Initialize scratchpad
   useEffect(() => {
     if (!data && fallback) {
-      setMatchScratchpad(match, fallback);
+      const id = getScratchpadID(match);
+      setMatchScratchpad(id, fallback);
     }
   }, [data, fallback, match]);
 
+  // Send out notifications when we change
   useEffect(() => {
     updateScratchpad({
       auto: autoWinner,
@@ -48,52 +56,113 @@ export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
     });
   }, [redAWP, blueAWP, autoWinner, updateScratchpad]);
 
+  // Update local variables when we get an update
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setAutoWinner(data.auto);
+    setRedAWP(data.awp.red);
+    setBlueAWP(data.awp.blue);
+  }, [data]);
+
   return (
     <section>
-      <section className="flex items-center bg-zinc-800 p-2 gap-4 mt-4 rounded-md">
-        <p className="w-1/2">Auto Winner</p>
-        <Radio
-          name="autoWinner"
-          label="Red"
-          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "red" }}
-          className="accent-red-400"
-          labelProps={{ className: "has-[:checked]:bg-red-800 mt-0 flex-1" }}
-        />
-        <Radio
-          name="autoWinner"
-          label="Blue"
-          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "blue" }}
-          className="accent-blue-400"
-          labelProps={{ className: "has-[:checked]:bg-blue-800 mt-0 flex-1" }}
-        />
-        <Radio
-          name="autoWinner"
-          label="Tie"
-          className="accent-purple-400"
-          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "tie" }}
-          labelProps={{ className: "has-[:checked]:bg-purple-800 mt-0 flex-1" }}
-        />
-        <Radio
-          name="autoWinner"
-          label="None"
-          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "none" }}
-          labelProps={{ className: "mt-0 flex-1" }}
-        />
+      <section className="bg-zinc-800 p-4 mt-4 rounded-md">
+        <div className="flex items-center gap-2">
+          <CodeBracketSquareIcon height={20} />
+          <p>Auto Winner</p>
+          <span>
+            {changeLog.auto ? (
+              <span className="text-sm ml-2 italic text-emerald-400">
+                {userString(changeLog.auto.user)},&nbsp;
+                {timeAgo(changeLog.auto.date)}
+              </span>
+            ) : null}
+          </span>
+        </div>
+        <fieldset className="mt-2 flex gap-2">
+          <Radio
+            name="autoWinner"
+            label="Red"
+            bind={{
+              value: autoWinner,
+              onChange: setAutoWinner,
+              variant: "red",
+            }}
+            className="accent-red-400"
+            labelProps={{
+              className: "has-[:checked]:bg-red-800 mt-0 flex-1 px-4",
+            }}
+          />
+          <Radio
+            name="autoWinner"
+            label="Blue"
+            bind={{
+              value: autoWinner,
+              onChange: setAutoWinner,
+              variant: "blue",
+            }}
+            className="accent-blue-400"
+            labelProps={{
+              className: "has-[:checked]:bg-blue-800 mt-0 flex-1 px-4",
+            }}
+          />
+          <Radio
+            name="autoWinner"
+            label="Tie"
+            className="accent-purple-400"
+            bind={{
+              value: autoWinner,
+              onChange: setAutoWinner,
+              variant: "tie",
+            }}
+            labelProps={{
+              className: "has-[:checked]:bg-purple-800 mt-0 flex-1 px-4",
+            }}
+          />
+          <Radio
+            name="autoWinner"
+            label="None"
+            bind={{
+              value: autoWinner,
+              onChange: setAutoWinner,
+              variant: "none",
+            }}
+            labelProps={{ className: "mt-0 flex-1 px-4" }}
+          />
+        </fieldset>
       </section>
-      <section className="flex items-center bg-zinc-800 p-2 gap-4 mt-4 rounded-md">
-        <p className="w-1/2">AWP</p>
-        <Checkbox
-          label="Red"
-          bind={{ value: redAWP, onChange: setRedAWP }}
-          className="accent-red-400 mt-0"
-          labelProps={{ className: "has-[:checked]:bg-red-800 mt-0 flex-1" }}
-        />
-        <Checkbox
-          label="Blue"
-          bind={{ value: blueAWP, onChange: setBlueAWP }}
-          className="accent-blue-400 mt-0"
-          labelProps={{ className: "has-[:checked]:bg-blue-800 mt-0 flex-1" }}
-        />
+      <section className="bg-zinc-800 p-4 mt-4 rounded-md">
+        <div className="flex items-center gap-2">
+          <StarIcon height={20} />
+          <p>AWP</p>
+          {changeLog.awp ? (
+            <span className="text-sm ml-2 italic text-emerald-400">
+              {userString(changeLog.awp.user)},&nbsp;
+              {timeAgo(changeLog.awp.date)}
+            </span>
+          ) : null}
+        </div>
+        <div className="mt-2 flex gap-2">
+          <Checkbox
+            label="Red"
+            bind={{ value: redAWP, onChange: setRedAWP }}
+            className="accent-red-400 mt-0"
+            labelProps={{
+              className: "has-[:checked]:bg-red-800 mt-0 flex-1 px-4",
+            }}
+          />
+          <Checkbox
+            label="Blue"
+            bind={{ value: blueAWP, onChange: setBlueAWP }}
+            className="accent-blue-400 mt-0"
+            labelProps={{
+              className: "has-[:checked]:bg-blue-800 mt-0 flex-1 px-4",
+            }}
+          />
+        </div>
       </section>
     </section>
   );

--- a/src/components/scratchpad/HighStakes.tsx
+++ b/src/components/scratchpad/HighStakes.tsx
@@ -1,0 +1,102 @@
+import { ClockIcon } from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
+import { MatchData } from "robotevents/out/endpoints/matches";
+import { IconButton } from "~components/Button";
+import { Checkbox, Radio } from "~components/Input";
+import { HighStakesMatchScratchpad } from "~share/MatchScratchpad";
+import { setMatchScratchpad } from "~utils/data/scratchpad";
+import {
+  useDefaultScratchpad,
+  useMatchScratchpad,
+  useUpdateMatchScratchpad,
+} from "~utils/hooks/scratchpad";
+
+export type HighStakesScratchpadProps = {
+  match: MatchData;
+};
+
+export const HighStakesScratchpad: React.FC<HighStakesScratchpadProps> = ({
+  match,
+}) => {
+  const { data: fallback } =
+    useDefaultScratchpad<HighStakesMatchScratchpad>(match);
+  const { data } = useMatchScratchpad<HighStakesMatchScratchpad>(match);
+  const { mutateAsync: updateScratchpad } =
+    useUpdateMatchScratchpad<HighStakesMatchScratchpad>(match);
+
+  const [autoWinner, setAutoWinner] = useState(
+    data ? data.auto : fallback?.auto ?? "none"
+  );
+
+  const [redAWP, setRedAWP] = useState(
+    data ? data.awp.red : fallback?.awp.red ?? false
+  );
+  const [blueAWP, setBlueAWP] = useState(
+    data ? data.awp.blue : fallback?.awp.blue ?? false
+  );
+
+  // Initialize scratchpad
+  useEffect(() => {
+    if (!data && fallback) {
+      setMatchScratchpad(match, fallback);
+    }
+  }, [data, fallback, match]);
+
+  useEffect(() => {
+    updateScratchpad({
+      auto: autoWinner,
+      awp: { red: redAWP, blue: blueAWP },
+      notes: "",
+    });
+  }, [redAWP, blueAWP, autoWinner, updateScratchpad]);
+
+  return (
+    <section>
+      <section className="flex items-center bg-zinc-800 p-2 gap-4 mt-4 rounded-md">
+        <p className="w-1/2">Auto Winner</p>
+        <Radio
+          name="autoWinner"
+          label="Red"
+          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "red" }}
+          className="accent-red-400"
+          labelProps={{ className: "has-[:checked]:bg-red-800 mt-0 flex-1" }}
+        />
+        <Radio
+          name="autoWinner"
+          label="Blue"
+          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "blue" }}
+          className="accent-blue-400"
+          labelProps={{ className: "has-[:checked]:bg-blue-800 mt-0 flex-1" }}
+        />
+        <Radio
+          name="autoWinner"
+          label="Tie"
+          className="accent-purple-400"
+          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "tie" }}
+          labelProps={{ className: "has-[:checked]:bg-purple-800 mt-0 flex-1" }}
+        />
+        <Radio
+          name="autoWinner"
+          label="None"
+          bind={{ value: autoWinner, onChange: setAutoWinner, variant: "none" }}
+          labelProps={{ className: "mt-0 flex-1" }}
+        />
+      </section>
+      <section className="flex items-center bg-zinc-800 p-2 gap-4 mt-4 rounded-md">
+        <p className="w-1/2">AWP</p>
+        <Checkbox
+          label="Red"
+          bind={{ value: redAWP, onChange: setRedAWP }}
+          className="accent-red-400 mt-0"
+          labelProps={{ className: "has-[:checked]:bg-red-800 mt-0 flex-1" }}
+        />
+        <Checkbox
+          label="Blue"
+          bind={{ value: blueAWP, onChange: setBlueAWP }}
+          className="accent-blue-400 mt-0"
+          labelProps={{ className: "has-[:checked]:bg-blue-800 mt-0 flex-1" }}
+        />
+      </section>
+    </section>
+  );
+};

--- a/src/components/scratchpad/Scratchpad.tsx
+++ b/src/components/scratchpad/Scratchpad.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+import { MatchData } from "robotevents/out/endpoints/matches";
+import { Year } from "robotevents/out/endpoints/seasons";
+import { useEvent, useSeason } from "~utils/hooks/robotevents";
+import { HighStakesScratchpad } from "./HighStakes";
+import { ProgramAbbr } from "robotevents/out/endpoints/programs";
+
+export type MatchScratchpadProps = {
+  match: MatchData;
+};
+
+export const MatchScratchpad: React.FC<MatchScratchpadProps> = ({ match }) => {
+  const { data: event } = useEvent(match.event.code);
+  const { data: season } = useSeason(event?.season.id);
+  const year = useMemo(
+    () => `${season?.years_start}-${season?.years_end}` as Year,
+    [season]
+  );
+
+  if (!event || !season) {
+    return null;
+  }
+
+  const combo = (event.program.code + year) as `${ProgramAbbr}${Year}`;
+  switch (combo) {
+    case "VAIRC2024-2025":
+    case "VURC2024-2025":
+    case "V5RC2023-2024":
+    case "V5RC2024-2025": {
+      return <HighStakesScratchpad key={match.id} match={match} />;
+    }
+    default: {
+      return null;
+    }
+  }
+};

--- a/src/migrations/2024_05_07_matchSkills.ts
+++ b/src/migrations/2024_05_07_matchSkills.ts
@@ -1,12 +1,10 @@
 import { getAllIncidents } from "~utils/data/incident";
 import { queueMigration } from "./utils";
 import {
-  ChangeLog,
   IncidentOutcome,
   Incident,
   IncidentMatch,
 } from "~share/EventIncidents";
-import { WebSocketSender } from "~share/api";
 import { setMany } from "idb-keyval";
 
 type OldIncident = {
@@ -23,11 +21,7 @@ type OldIncident = {
   };
   team?: string; // team number
 
-  revision?: {
-    count: number;
-    user: WebSocketSender;
-    history: ChangeLog[];
-  };
+  revision?: Incident["revision"];
 
   outcome: IncidentOutcome;
   rules: string[];

--- a/src/migrations/2024_05_07_matchSkills.ts
+++ b/src/migrations/2024_05_07_matchSkills.ts
@@ -5,7 +5,7 @@ import {
   Incident,
   IncidentMatch,
 } from "~share/EventIncidents";
-import { setMany } from "idb-keyval";
+import { setMany } from "~utils/data/keyval";
 
 type OldIncident = {
   id: string;

--- a/src/migrations/2024_07_11_setIndices.ts
+++ b/src/migrations/2024_07_11_setIndices.ts
@@ -1,0 +1,28 @@
+import { getAllIncidents } from "~utils/data/incident";
+import { queueMigration } from "./utils";
+import { getMany, setMany } from "idb-keyval";
+
+queueMigration({
+  name: `2024_07_11_setIndices`,
+  run_order: 1,
+  dependencies: ["2024_05_17_splitIndex"],
+  apply: async () => {
+    const processedIndices = new Set<string>();
+    const incidents = await getAllIncidents();
+
+    for (const incident of incidents) {
+      const indices = [
+        `event_${incident.event}_idx`,
+        `team_${incident.team}_idx`,
+        `deleted_event_${incident.event}_idx`,
+        `deleted_team_${incident.team}_idx`,
+      ];
+
+      const unprocessed = indices.filter((t) => !processedIndices.has(t));
+      const old = await getMany<Set<string> | string[]>(unprocessed);
+      await setMany(old.map((v, i) => [unprocessed[i], new Set(v)]));
+    }
+
+    return { success: true };
+  },
+});

--- a/src/migrations/2024_07_11_setIndices.ts
+++ b/src/migrations/2024_07_11_setIndices.ts
@@ -1,6 +1,6 @@
 import { getAllIncidents } from "~utils/data/incident";
 import { queueMigration } from "./utils";
-import { getMany, setMany } from "idb-keyval";
+import { getMany, setMany } from "~utils/data/keyval";
 
 queueMigration({
   name: `2024_07_11_setIndices`,

--- a/src/migrations/2024_07_12_setIndicesAll.ts
+++ b/src/migrations/2024_07_12_setIndicesAll.ts
@@ -1,0 +1,12 @@
+import { queueMigration } from "./utils";
+import { update } from "~utils/data/keyval";
+
+queueMigration({
+  name: `2024_07_12_setIndicesAll`,
+  run_order: 1,
+  dependencies: ["2024_05_17_splitIndex"],
+  apply: async () => {
+    await update<Set<string> | string[]>("incidents", (old) => new Set(old));
+    return { success: true };
+  },
+});

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import "./2024_05_07_matchSkills";
 import "./2024_05_17_splitIndex";
 import "./2024_07_11_setIndices";
+import "./2024_07_12_setIndicesAll";
 
 export { runMigrations } from "./utils";

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,4 +1,5 @@
 import "./2024_05_07_matchSkills";
 import "./2024_05_17_splitIndex";
+import "./2024_07_11_setIndices";
 
 export { runMigrations } from "./utils";

--- a/src/migrations/utils.ts
+++ b/src/migrations/utils.ts
@@ -36,18 +36,29 @@ export async function applyMigration(
   }
 
   const start = performance.now();
-  const output = await migration.apply(result);
-  const end = performance.now();
+  try {
+    const output = await migration.apply(result);
+    const end = performance.now();
 
-  const newResult: MigrationResult = {
-    ...output,
-    date: new Date(),
-    duration: end - start,
-  };
+    const newResult: MigrationResult = {
+      ...output,
+      date: new Date(),
+      duration: end - start,
+    };
 
-  await set(`migration_${migration.name}`, newResult);
+    await set(`migration_${migration.name}`, newResult);
 
-  return { ...newResult, preapplied: false };
+    return { ...newResult, preapplied: false };
+  } catch (e) {
+    const newResult: MigrationResult = {
+      date: new Date(),
+      duration: performance.now() - start,
+      success: false,
+      details: `${e}`,
+    };
+    await set(`migration_${migration.name}`, newResult);
+    return { ...newResult, preapplied: false };
+  }
 }
 
 export const MIGRATION_QUEUE: Migration[] = [];

--- a/src/migrations/utils.ts
+++ b/src/migrations/utils.ts
@@ -1,4 +1,4 @@
-import { get, set } from "idb-keyval";
+import { get, set } from "~utils/data/keyval";
 
 export type Migration = {
   name: string;

--- a/src/models/ShareConnection.ts
+++ b/src/models/ShareConnection.ts
@@ -35,6 +35,7 @@ import {
 import { queryClient } from "~utils/data/query";
 import { toast } from "~components/Toast";
 import { MatchScratchpad } from "~share/MatchScratchpad";
+import { setMatchScratchpad } from "~utils/data/scratchpad";
 
 export enum ReadyState {
   Closed = WebSocket.CLOSED,
@@ -188,7 +189,11 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
         queryClient.invalidateQueries({ queryKey: ["incidents"] });
         break;
       }
-
+      case "scratchpad_update": {
+        await setMatchScratchpad(data.id, data.scratchpad);
+        queryClient.invalidateQueries({ queryKey: ["scratchpad"] });
+        break;
+      }
       case "server_user_add": {
         toast({ type: "info", message: `${data.user.name} joined.` });
         set({ activeUsers: data.activeUsers, invitations: data.invitations });

--- a/src/models/ShareConnection.ts
+++ b/src/models/ShareConnection.ts
@@ -87,6 +87,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
       invitations: get().invitations,
       date: new Date().toISOString(),
       data: response.data.data,
+      scratchpads: response.data.scratchpads,
       sender: { type: "server" },
     });
 

--- a/src/models/ShareConnection.ts
+++ b/src/models/ShareConnection.ts
@@ -20,12 +20,15 @@ import {
 import { signWebSocketConnectionURL } from "~utils/data/crypto";
 import {
   deleteIncident,
-  getIncident,
+  deleteManyIncidents,
   getIncidentsByEvent,
+  getManyIncidents,
   hasIncident,
+  hasManyIncidents,
   newIncident,
-  repairIndices,
+  newManyIncidents,
   setIncident,
+  setManyIncidents,
 } from "~utils/data/incident";
 import { queryClient } from "~utils/data/query";
 import { toast } from "~components/Toast";
@@ -103,6 +106,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
   },
 
   handleWebsocketMessage: async (data: WebSocketPayload<WebSocketMessage>) => {
+    console.log("message", performance.now(), data);
     switch (data.type) {
       case "add_incident": {
         const has = await hasIncident(data.incident.id);
@@ -129,52 +133,50 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
       case "server_share_info": {
         set({ activeUsers: data.activeUsers, invitations: data.invitations });
 
-        for (const incident of data.data.incidents) {
-          const has = await hasIncident(incident.id);
+        const hasIncidents = await hasManyIncidents(
+          data.data.incidents.map((i) => i.id)
+        );
 
-          // Handle newly created incidents
-          if (!has) {
-            await newIncident(incident, false, incident.id);
+        // Incidents that have been created newly created on other devices
+        const remoteOnly = data.data.incidents.filter(
+          (_, i) => !hasIncidents[i]
+        );
+        await newManyIncidents(remoteOnly);
 
-            // Handle any incidents with different revisions while offline
-          } else {
-            await repairIndices(incident.id, incident);
+        // Handle incidents that may have changed
+        const localAndRemote = data.data.incidents.filter(
+          (_, i) => hasIncidents[i]
+        );
+        const current = await getManyIncidents(localAndRemote.map((i) => i.id));
 
-            const current = (await getIncident(incident.id))!;
+        const localMoreRecent = localAndRemote.filter(
+          (remote, i) =>
+            (remote.revision?.count ?? 0) < (current[i]?.revision?.count ?? 0)
+        );
+        const remoteMoreRecent = localAndRemote.filter(
+          (remote, i) =>
+            (remote.revision?.count ?? 0) > (current[i]?.revision?.count ?? 0)
+        );
+        await setManyIncidents(remoteMoreRecent);
+        await Promise.all(
+          localMoreRecent.map((incident) => editServerIncident(incident))
+        );
 
-            const localRevision = current.revision?.count ?? 0;
-            const remoteRevision = incident.revision?.count ?? 0;
+        // Explicitly delete incidents marked as deleted
+        await deleteManyIncidents(data.data.deleted);
 
-            if (localRevision > remoteRevision) {
-              const response = await editServerIncident(current);
-              if (response?.success) {
-                current.revision = response.data;
-              }
-              await setIncident(incident.id, current);
-              queryClient.invalidateQueries({ queryKey: ["incidents"] });
-            }
-
-            if (remoteRevision > localRevision) {
-              await setIncident(incident.id, incident);
-              queryClient.invalidateQueries({ queryKey: ["incidents"] });
-            }
-          }
-        }
-
-        // Explicitly delete incidents marked as deleted first.
-        for (const id of data.data.deleted) {
-          await deleteIncident(id, false);
-        }
-
-        const eventIncidents = await getIncidentsByEvent(get().invitation!.sku);
+        // Send message to other clients for local-only incidents
+        const eventIncidents = await getIncidentsByEvent(data.data.sku);
         const localOnly = eventIncidents.filter((local) =>
           data.data.incidents.every((remote) => local.id !== remote.id)
         );
 
-        for (const incident of localOnly) {
-          await get().addIncident(incident);
-        }
+        const store = get();
+        await Promise.all(
+          localOnly.map((incident) => store.addIncident(incident))
+        );
 
+        queryClient.invalidateQueries({ queryKey: ["incidents"] });
         break;
       }
 

--- a/src/models/ShareConnection.ts
+++ b/src/models/ShareConnection.ts
@@ -172,7 +172,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
         );
 
         for (const incident of localOnly) {
-          await get().send({ type: "add_incident", incident });
+          await get().addIncident(incident);
         }
 
         break;
@@ -209,7 +209,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
   },
 
   addIncident: async (incident: Incident) => {
-    const connected = get().readyState !== WebSocket.OPEN;
+    const connected = get().readyState === WebSocket.OPEN;
     if (!connected) {
       await addServerIncident(incident);
     }
@@ -218,7 +218,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
   },
 
   editIncident: async (incident: Incident) => {
-    const connected = get().readyState !== WebSocket.OPEN;
+    const connected = get().readyState === WebSocket.OPEN;
     if (!connected) {
       await editServerIncident(incident);
     }
@@ -227,7 +227,7 @@ export const useShareConnection = create<ShareConnection>((set, get) => ({
   },
 
   deleteIncident: async (id: string, sku: string) => {
-    const connected = get().readyState !== WebSocket.OPEN;
+    const connected = get().readyState === WebSocket.OPEN;
     if (!connected) {
       await deleteServerIncident(id, sku);
     }

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -21,7 +21,10 @@ import {
   useTeamIncidentsByMatch,
 } from "~utils/hooks/incident";
 import { EventNewIncidentDialog } from "./new";
-import { IncidentOutcome, IncidentWithID } from "~utils/data/incident";
+import {
+  IncidentOutcome,
+  Incident as IncidentData,
+} from "~utils/data/incident";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { MatchContext } from "~components/Context";
 import { Incident } from "~components/Incident";
@@ -41,7 +44,7 @@ const OUTCOME_PRIORITY: IncidentOutcome[] = [
 type TeamSummaryProps = {
   number: string;
   match: MatchData;
-  incidents: IncidentWithID[];
+  incidents: IncidentData[];
 };
 
 const TeamSummary: React.FC<TeamSummaryProps> = ({
@@ -74,7 +77,7 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
   );
 
   const rulesSummary = useMemo(() => {
-    const rules: Record<string, IncidentWithID[]> = {};
+    const rules: Record<string, IncidentData[]> = {};
 
     for (const incident of incidents) {
       if (incident.outcome === "General") {

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -29,6 +29,7 @@ import { TeamData } from "robotevents/out/endpoints/teams";
 import { MatchTime } from "~components/Match";
 import { TeamIsolationDialog } from "./team";
 import { ArrowsPointingOutIcon } from "@heroicons/react/24/outline";
+import { MatchScratchpad } from "~components/scratchpad/Scratchpad";
 
 const OUTCOME_PRIORITY: IncidentOutcome[] = [
   "Major",
@@ -172,6 +173,7 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
       {incidents.length > 0 ? (
         <>
           <TeamIsolationDialog
+            key={team?.number}
             team={team?.number}
             open={isolationOpen}
             setOpen={setIsolationOpen}
@@ -315,11 +317,11 @@ export const EventMatchDialog: React.FC<EventMatchDialogProps> = ({
               )}
             />
           </nav>
-          {match ? (
+          {match && incidentsByTeam ? (
             <div className="mt-4 mx-2">
               <MatchContext match={match} allianceClassName="w-full" />
               <section className="mt-4">
-                {incidentsByTeam?.map(({ team: number, incidents }) => (
+                {incidentsByTeam.map(({ team: number, incidents }) => (
                   <TeamSummary
                     key={number}
                     incidents={incidents}
@@ -328,6 +330,7 @@ export const EventMatchDialog: React.FC<EventMatchDialogProps> = ({
                   />
                 ))}
               </section>
+              <MatchScratchpad match={match} />
             </div>
           ) : null}
         </DialogBody>

--- a/src/pages/events/dialogs/team.tsx
+++ b/src/pages/events/dialogs/team.tsx
@@ -30,7 +30,7 @@ export const TeamIsolationDialog: React.FC<TeamIsolationDialogProps> = ({
       <DialogHeader title={team} onClose={() => setOpen(false)} />
       <DialogBody>
         {incidents?.map((incident) => (
-          <Incident incident={incident} readonly />
+          <Incident key={incident.id} incident={incident} readonly />
         ))}
       </DialogBody>
     </Dialog>

--- a/src/pages/events/home/manage.tsx
+++ b/src/pages/events/home/manage.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EventData } from "robotevents/out/endpoints/events";
 import { Button, IconButton, LinkButton } from "~components/Button";
-import { deleteIncident, getIncidentsByEvent } from "~utils/data/incident";
+import {
+  deleteManyIncidents,
+  editIncident,
+  getIncidentsByEvent,
+} from "~utils/data/incident";
 import {
   acceptEventInvitation,
   fetchInvitation,
@@ -322,9 +326,22 @@ export const EventManageTab: React.FC<ManageTabProps> = ({ event }) => {
   const onConfirmDeleteData = useCallback(async () => {
     const incidents = await getIncidentsByEvent(event.sku);
     await removeInvitation(event.sku);
-    for (const incident of incidents) {
-      await deleteIncident(incident.id);
-    }
+
+    const toDelete = incidents.filter((_, i) => i % 2 === 0);
+    const toEdit = incidents.filter((_, i) => i % 2 === 1);
+
+    console.log("toEdit", toEdit);
+    console.log("toDelete", toDelete);
+
+    await deleteManyIncidents(toDelete.map((i) => i.id));
+
+    const edited = toEdit.map((i) => ({
+      ...i,
+      notes: i.notes + `\nETA: ${new Date().toString()}`,
+    }));
+
+    await Promise.all(edited.map((i) => editIncident(i.id, i, false)));
+
     setDeleteDataDialogOpen(false);
   }, [event.sku]);
 

--- a/src/pages/events/home/manage.tsx
+++ b/src/pages/events/home/manage.tsx
@@ -327,7 +327,7 @@ export const EventManageTab: React.FC<ManageTabProps> = ({ event }) => {
   }, [event.sku]);
 
   return (
-    <section className="max-w-xl w-full mx-auto flex-1">
+    <section className="max-w-xl w-full mx-auto flex-1 mb-4">
       <JoinCodeDialog
         sku={event.sku}
         open={joinCodeDialogOpen}

--- a/src/pages/events/home/manage.tsx
+++ b/src/pages/events/home/manage.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EventData } from "robotevents/out/endpoints/events";
 import { Button, IconButton, LinkButton } from "~components/Button";
-import {
-  deleteManyIncidents,
-  editIncident,
-  getIncidentsByEvent,
-} from "~utils/data/incident";
+import { deleteManyIncidents, getIncidentsByEvent } from "~utils/data/incident";
 import {
   acceptEventInvitation,
   fetchInvitation,
@@ -326,22 +322,7 @@ export const EventManageTab: React.FC<ManageTabProps> = ({ event }) => {
   const onConfirmDeleteData = useCallback(async () => {
     const incidents = await getIncidentsByEvent(event.sku);
     await removeInvitation(event.sku);
-
-    const toDelete = incidents.filter((_, i) => i % 2 === 0);
-    const toEdit = incidents.filter((_, i) => i % 2 === 1);
-
-    console.log("toEdit", toEdit);
-    console.log("toDelete", toDelete);
-
-    await deleteManyIncidents(toDelete.map((i) => i.id));
-
-    const edited = toEdit.map((i) => ({
-      ...i,
-      notes: i.notes + `\nETA: ${new Date().toString()}`,
-    }));
-
-    await Promise.all(edited.map((i) => editIncident(i.id, i, false)));
-
+    await deleteManyIncidents(incidents.map((i) => i.id));
     setDeleteDataDialogOpen(false);
   }, [event.sku]);
 

--- a/src/pages/events/summary.tsx
+++ b/src/pages/events/summary.tsx
@@ -291,7 +291,10 @@ export const EventSummaryPage: React.FC = () => {
         </nav>
         <section className="flex gap-1 flex-wrap">
           {commonRules.slice(0, 5).map(([rule, count]) => (
-            <p className="font-mono bg-emerald-900 rounded-lg px-2 py-1 text-sm text-center">
+            <p
+              className="font-mono bg-emerald-900 rounded-lg px-2 py-1 text-sm text-center"
+              key={rule}
+            >
               {rule.replace(/[<>]/g, "")}{" "}
               <span className="text-emerald-400">{count}</span>
             </p>

--- a/src/utils/data/crypto.ts
+++ b/src/utils/data/crypto.ts
@@ -1,4 +1,4 @@
-import { get, set } from "idb-keyval";
+import { get, set } from "~utils/data/keyval";
 
 export const PUBLIC_KEY = "public_key";
 export const PRIVATE_KEY = "private_key";

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -15,9 +15,10 @@ import {
   IncidentMatch,
   IncidentMatchSkills,
   IncidentOutcome,
-  Revision,
   Incident as ServerIncident,
+  UnchangeableProperties,
 } from "~share/api";
+import { Change } from "~share/revision";
 
 export type Incident = Omit<ServerIncident, "id">;
 export type IncidentWithID = ServerIncident;
@@ -216,7 +217,7 @@ export async function editIncident(
   }
 
   // Annoying type coercion to support the strongly typed revision array
-  const changes: Revision[] = [];
+  const changes: Change<Incident, UnchangeableProperties>[] = [];
   for (const [key, currentValue] of Object.entries(current)) {
     if (key === "revision" || key === "team" || key === "event") continue;
 
@@ -227,7 +228,7 @@ export async function editIncident(
         property: key,
         old: currentValue,
         new: newValue,
-      } as Revision);
+      } as Change<Incident, UnchangeableProperties>);
     }
   }
 
@@ -293,9 +294,9 @@ export async function deleteIncident(
 }
 
 export async function getAllIncidents(): Promise<IncidentWithID[]> {
-  const ids = await get<string[]>(`incidents`);
+  const ids = await get<Set<string>>(`incidents`);
   if (!ids) return [];
-  const incidents = await getManyIncidents(ids);
+  const incidents = await getManyIncidents([...ids]);
 
   return incidents.filter((i) => !!i) as IncidentWithID[];
 }
@@ -303,9 +304,9 @@ export async function getAllIncidents(): Promise<IncidentWithID[]> {
 export async function getIncidentsByEvent(
   event: string
 ): Promise<IncidentWithID[]> {
-  const ids = await get<string[]>(`event_${event}_idx`);
+  const ids = await get<Set<string>>(`event_${event}_idx`);
   if (!ids) return [];
-  const incidents = await getManyIncidents(ids);
+  const incidents = await getManyIncidents([...ids]);
 
   return incidents.filter((i) => !!i) as IncidentWithID[];
 }
@@ -313,9 +314,9 @@ export async function getIncidentsByEvent(
 export async function getIncidentsByTeam(
   team: string
 ): Promise<IncidentWithID[]> {
-  const ids = await get<string[]>(`team_${team}_idx`);
+  const ids = await get<Set<string>>(`team_${team}_idx`);
   if (!ids) return [];
-  const incidents = await getManyIncidents(ids);
+  const incidents = await getManyIncidents([...ids]);
 
   return incidents.filter((i) => !!i) as IncidentWithID[];
 }

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -3,13 +3,7 @@ import { v1 as uuid } from "uuid";
 import { Rule } from "~hooks/rules";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { TeamData } from "robotevents/out/endpoints/teams";
-import {
-  addServerIncident,
-  deleteServerIncident,
-  editServerIncident,
-  getEventInvitation,
-  getSender,
-} from "./share";
+import { getEventInvitation, getSender } from "./share";
 import {
   EditIncident,
   IncidentMatch,
@@ -19,6 +13,7 @@ import {
   UnchangeableProperties,
 } from "~share/api";
 import { Change } from "~share/revision";
+import { useShareConnection } from "~models/ShareConnection";
 
 export type Incident = Omit<ServerIncident, "id">;
 export type IncidentWithID = ServerIncident;
@@ -199,7 +194,7 @@ export async function newIncident(
 
   const invitation = await getEventInvitation(incident.event);
   if (updateRemote && invitation && invitation.accepted) {
-    await addServerIncident({ ...incident, id });
+    useShareConnection.getState().addIncident({ id, ...incident });
   }
 
   return id;
@@ -252,7 +247,7 @@ export async function editIncident(
 
   const invitation = await getEventInvitation(current.event);
   if (updateRemote && invitation && invitation.accepted) {
-    await editServerIncident(updatedIncident);
+    useShareConnection.getState().editIncident(updatedIncident);
   }
 }
 
@@ -289,7 +284,7 @@ export async function deleteIncident(
 
   const invitation = await getEventInvitation(incident.event);
   if (updateRemote && invitation && invitation.accepted) {
-    await deleteServerIncident(id, incident.event);
+    useShareConnection.getState().deleteIncident(id, incident.event);
   }
 }
 

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -1,4 +1,4 @@
-import { get, getMany, set, setMany } from "idb-keyval";
+import { get, getMany, set, setMany } from "~utils/data/keyval";
 import { v1 as uuid } from "uuid";
 import { Rule } from "~hooks/rules";
 import { MatchData } from "robotevents/out/endpoints/matches";

--- a/src/utils/data/incident.ts
+++ b/src/utils/data/incident.ts
@@ -7,6 +7,7 @@ import {
   addServerIncident,
   deleteServerIncident,
   editServerIncident,
+  getEventInvitation,
   getSender,
 } from "./share";
 import {
@@ -280,7 +281,8 @@ export async function deleteIncident(
     team: deletedTeam,
   });
 
-  if (updateRemote) {
+  const invitation = await getEventInvitation(incident.event);
+  if (updateRemote && invitation && invitation.accepted) {
     await deleteServerIncident(id, incident.event);
   }
 }

--- a/src/utils/data/keyval.ts
+++ b/src/utils/data/keyval.ts
@@ -29,15 +29,15 @@ export function update<T>(
 
 export function updateMany<T>(
   keys: IDBValidKey[],
-  updater: (old: T | undefined, key: IDBValidKey) => T
+  updater: (entries: [IDBValidKey, T | undefined][]) => [IDBValidKey, T][]
 ) {
   return customStore("readwrite", async (store) => {
     const oldValues = await Promise.all(
       keys.map((key) => kv.promisifyRequest<T | undefined>(store.get(key)))
     );
-    oldValues.forEach((oldValue, i) =>
-      store.put(updater(oldValue, keys[i]), keys[i])
-    );
+
+    const values = updater(oldValues.map((value, i) => [keys[i], value]));
+    values.forEach((entry) => store.put(entry[1], entry[0]));
     return kv.promisifyRequest(store.transaction);
   });
 }

--- a/src/utils/data/keyval.ts
+++ b/src/utils/data/keyval.ts
@@ -1,0 +1,55 @@
+import { createStore } from "idb-keyval";
+
+import * as kv from "idb-keyval";
+
+const customStore = createStore("keyval-store", "keyval");
+
+export function get<T>(key: IDBValidKey) {
+  return kv.get<T>(key, customStore);
+}
+
+export function set(key: IDBValidKey, value: unknown) {
+  return kv.set(key, value, customStore);
+}
+
+export function setMany(entries: [IDBValidKey, unknown][]) {
+  return kv.setMany(entries, customStore);
+}
+
+export function getMany<T>(entries: IDBValidKey[]) {
+  return kv.getMany<T | undefined>(entries, customStore);
+}
+
+export function update<T>(
+  key: IDBValidKey,
+  updater: (old: T | undefined) => T
+) {
+  return kv.update<T>(key, updater, customStore);
+}
+
+export function updateMany<T>(
+  keys: IDBValidKey[],
+  updater: (old: T | undefined, key: IDBValidKey) => T
+) {
+  return customStore("readwrite", async (store) => {
+    const oldValues = await Promise.all(
+      keys.map((key) => kv.promisifyRequest<T | undefined>(store.get(key)))
+    );
+    oldValues.forEach((oldValue, i) =>
+      store.put(updater(oldValue, keys[i]), keys[i])
+    );
+    return kv.promisifyRequest(store.transaction);
+  });
+}
+
+export function del(key: IDBValidKey) {
+  return kv.del(key, customStore);
+}
+
+export function delMany(key: IDBValidKey[]) {
+  return kv.delMany(key, customStore);
+}
+
+export function keys<K extends IDBValidKey>() {
+  return kv.keys<K>(customStore);
+}

--- a/src/utils/data/query.ts
+++ b/src/utils/data/query.ts
@@ -3,7 +3,7 @@ import {
   PersistedQuery,
   experimental_createPersister,
 } from "@tanstack/react-query-persist-client";
-import { del, get, set } from "idb-keyval";
+import { del, get, set } from "~utils/data/keyval";
 
 // Cache buster key, used to forcibly invalidate queries
 export const CACHE_BUSTER = "v6";

--- a/src/utils/data/report.ts
+++ b/src/utils/data/report.ts
@@ -1,4 +1,4 @@
-import { getMany, keys } from "idb-keyval";
+import { getMany, keys } from "~utils/data/keyval";
 import { PRIVATE_KEY } from "./crypto";
 import { CACHE_PREFIX } from "./query";
 import { getShareSessionID } from "./share";

--- a/src/utils/data/revision.ts
+++ b/src/utils/data/revision.ts
@@ -1,0 +1,47 @@
+import { WithRevision } from "~share/revision";
+
+function getRevisionCount<T, U>(data: WithRevision<T, U>) {
+  return data.revision?.count ?? 0;
+}
+
+function setIdToRecord<T>(
+  set: Set<string>,
+  values: Record<string, T>
+): Record<string, T> {
+  return Object.fromEntries([...set].map((id) => [id, values[id]]));
+}
+
+export type LocalRemoteComparison<T, U> = {
+  localOnly: Record<string, WithRevision<T, U>>;
+  remoteOnly: Record<string, WithRevision<T, U>>;
+  localMoreRecent: Record<string, WithRevision<T, U>>;
+  remoteMoreRecent: Record<string, WithRevision<T, U>>;
+};
+
+export function compareLocalAndRemote<T, U>(
+  local: Record<string, WithRevision<T, U>>,
+  remote: Record<string, WithRevision<T, U>>
+): LocalRemoteComparison<T, U> {
+  const localIds = new Set(Object.keys(local));
+  const remoteIds = new Set(Object.keys(remote));
+
+  console.log(local, remote);
+
+  const remoteOnlyIds = remoteIds.difference(localIds);
+  const localOnlyIds = localIds.difference(remoteIds);
+
+  const bothIds = remoteIds.intersection(localIds);
+  const remoteMoreRecentIds = [...bothIds].filter(
+    (id) => getRevisionCount(local[id]) < getRevisionCount(remote[id])
+  );
+  const localMoreRecentIds = [...bothIds].filter(
+    (id) => getRevisionCount(local[id]) > getRevisionCount(remote[id])
+  );
+
+  return {
+    localOnly: setIdToRecord(localOnlyIds, local),
+    remoteOnly: setIdToRecord(remoteOnlyIds, remote),
+    remoteMoreRecent: setIdToRecord(new Set(remoteMoreRecentIds), remote),
+    localMoreRecent: setIdToRecord(new Set(localMoreRecentIds), local),
+  };
+}

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -13,11 +13,18 @@ import { Change } from "~share/revision";
 import { MatchData } from "robotevents/out/endpoints/matches";
 import { WebSocketSender } from "~share/api";
 import { seasons } from "robotevents";
+import { useShareConnection } from "~models/ShareConnection";
+
+export function getScratchpadID(match: MatchData) {
+  return `scratchpad_${match.event.code}_${
+    match.division.id
+  }_${match.name.replace(/ /g, "")}`;
+}
 
 export async function getMatchScratchpad<T extends MatchScratchpad>(
   match: MatchData
 ): Promise<T | undefined> {
-  const id = `scratchpad_${match.event.code}_${match.division.id}_${match.name}`;
+  const id = getScratchpadID(match);
   const data = await get<T>(id);
   return data;
 }
@@ -26,7 +33,7 @@ export async function setMatchScratchpad(
   match: MatchData,
   scratchpad: MatchScratchpad
 ) {
-  const id = `scratchpad_${match.event.code}_${match.division.id}_${match.name}`;
+  const id = getScratchpadID(match);
   return set(id, scratchpad);
 }
 
@@ -74,11 +81,15 @@ export async function editScratchpad<T extends MatchScratchpad>(
     changes,
   });
 
-  await setMatchScratchpad(match, {
+  const value = {
     ...current,
     ...scratchpad,
     revision,
-  });
+  };
+
+  const id = getScratchpadID(match);
+  useShareConnection.getState().updateScratchpad(id, value);
+  await setMatchScratchpad(match, value);
 }
 
 export function getGameForSeason(seasonId: number): SupportedGame | null {

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -1,4 +1,4 @@
-import { get, set } from "idb-keyval";
+import { get, set } from "~utils/data/keyval";
 import {
   BaseMatchScratchpad,
   EditScratchpad,

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -1,0 +1,146 @@
+import { get, set } from "idb-keyval";
+import {
+  BaseMatchScratchpad,
+  EditScratchpad,
+  HighStakesMatchScratchpad,
+  MatchScratchpad,
+  RapidRelayMatchScratchpad,
+  SupportedGame,
+  UnchangeableProperties,
+} from "~share/MatchScratchpad";
+import { getSender } from "./share";
+import { Change } from "~share/revision";
+import { MatchData } from "robotevents/out/endpoints/matches";
+import { WebSocketSender } from "~share/api";
+import { seasons } from "robotevents";
+
+export async function getMatchScratchpad<T extends MatchScratchpad>(
+  match: MatchData
+): Promise<T | undefined> {
+  const id = `scratchpad_${match.event.code}_${match.division.id}_${match.name}`;
+  const data = await get<T>(id);
+  return data;
+}
+
+export async function setMatchScratchpad(
+  match: MatchData,
+  scratchpad: MatchScratchpad
+) {
+  const id = `scratchpad_${match.event.code}_${match.division.id}_${match.name}`;
+  return set(id, scratchpad);
+}
+
+export async function editScratchpad<T extends MatchScratchpad>(
+  match: MatchData,
+  scratchpad: EditScratchpad<T>
+) {
+  const current = await getMatchScratchpad(match);
+
+  if (!current) {
+    return;
+  }
+
+  const changes: Change<MatchScratchpad, UnchangeableProperties>[] = [];
+  for (const [key, currentValue] of Object.entries(scratchpad)) {
+    if (["event", "match", "revision", "game"].includes(key)) continue;
+
+    const newValue = current[key as keyof MatchScratchpad];
+
+    if (JSON.stringify(currentValue) != JSON.stringify(newValue)) {
+      changes.push({
+        property: key,
+        old: currentValue,
+        new: newValue,
+      } as Change<MatchScratchpad, UnchangeableProperties>);
+    }
+  }
+
+  if (changes.length < 1) {
+    return;
+  }
+
+  const user = await getSender();
+
+  const revision = current.revision ?? {
+    count: 0,
+    user,
+    history: [],
+  };
+
+  revision.count += 1;
+  revision.history.push({
+    user,
+    date: new Date(),
+    changes,
+  });
+
+  await setMatchScratchpad(match, {
+    ...current,
+    ...scratchpad,
+    revision,
+  });
+}
+
+export function getGameForSeason(seasonId: number): SupportedGame | null {
+  switch (seasonId) {
+    case seasons.get("V5RC", "2024-2025")!: {
+      return "High Stakes";
+    }
+    case seasons.get("V5RC", "2023-2024")!: {
+      return "High Stakes";
+    }
+    case seasons.get("VURC", "2024-2025")!: {
+      return "High Stakes";
+    }
+    case seasons.get("VAIRC", "2024-2025")!: {
+      return "High Stakes";
+    }
+    case seasons.get("VIQRC", "2024-2025")!: {
+      return "Rapid Relay";
+    }
+    default: {
+      return null;
+    }
+  }
+}
+
+export function getDefaultScratchpad(
+  match: MatchData,
+  user: WebSocketSender,
+  game: SupportedGame
+): MatchScratchpad {
+  const base: BaseMatchScratchpad = {
+    event: match.event.code,
+    match: {
+      type: "match",
+      division: match.division.id,
+      name: match.name,
+      id: match.id,
+    },
+    game,
+    notes: "",
+  };
+
+  const revision = { count: 0, user, history: [] };
+
+  switch (game) {
+    case "High Stakes": {
+      const data: HighStakesMatchScratchpad = {
+        ...base,
+        game,
+        revision,
+        awp: { red: false, blue: false },
+        auto: "none",
+      };
+      return data;
+    }
+    case "Rapid Relay": {
+      const data: RapidRelayMatchScratchpad = {
+        ...base,
+        game,
+        revision,
+      };
+      return data;
+    }
+  }
+}

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -1,4 +1,4 @@
-import { get, set } from "~utils/data/keyval";
+import { get, getMany, set, setMany, update } from "~utils/data/keyval";
 import {
   BaseMatchScratchpad,
   EditScratchpad,
@@ -28,11 +28,33 @@ export async function getMatchScratchpad<T extends MatchScratchpad>(
   return data;
 }
 
+export async function getManyMatchScratchpads<T extends MatchScratchpad>(
+  ids: string[]
+): Promise<Record<string, T>> {
+  const values = await getMany<T>(ids);
+  return Object.fromEntries(ids.map((id, i) => [id, values[i]!]));
+}
+
 export async function setMatchScratchpad(
   id: string,
   scratchpad: MatchScratchpad
 ) {
+  await update<Set<string>>(
+    `scratchpad_${scratchpad.event}_idx`,
+    (old) => old?.add(id) ?? new Set(id)
+  );
   return set(id, scratchpad);
+}
+
+export async function getScratchpadIdsForEvent(sku: string) {
+  const data = await get<Set<string>>(`scratchpad_${sku}_idx`);
+  return data ?? new Set();
+}
+
+export async function setManyMatchScratchpad(
+  entries: [id: string, scratchpad: MatchScratchpad][]
+) {
+  return setMany(entries);
 }
 
 export async function editScratchpad<T extends MatchScratchpad>(

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -22,26 +22,24 @@ export function getScratchpadID(match: MatchData) {
 }
 
 export async function getMatchScratchpad<T extends MatchScratchpad>(
-  match: MatchData
+  id: string
 ): Promise<T | undefined> {
-  const id = getScratchpadID(match);
   const data = await get<T>(id);
   return data;
 }
 
 export async function setMatchScratchpad(
-  match: MatchData,
+  id: string,
   scratchpad: MatchScratchpad
 ) {
-  const id = getScratchpadID(match);
   return set(id, scratchpad);
 }
 
 export async function editScratchpad<T extends MatchScratchpad>(
-  match: MatchData,
+  id: string,
   scratchpad: EditScratchpad<T>
 ) {
-  const current = await getMatchScratchpad(match);
+  const current = await getMatchScratchpad(id);
 
   if (!current) {
     return;
@@ -87,9 +85,8 @@ export async function editScratchpad<T extends MatchScratchpad>(
     revision,
   };
 
-  const id = getScratchpadID(match);
   useShareConnection.getState().updateScratchpad(id, value);
-  await setMatchScratchpad(match, value);
+  await setMatchScratchpad(id, value);
 }
 
 export function getGameForSeason(seasonId: number): SupportedGame | null {

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -21,27 +21,27 @@ export function getScratchpadID(match: MatchData) {
   }_${match.name.replace(/ /g, "")}`;
 }
 
-export async function getMatchScratchpad<T extends MatchScratchpad>(
+export async function getMatchScratchpad<T extends BaseMatchScratchpad>(
   id: string
 ): Promise<T | undefined> {
   const data = await get<T>(id);
   return data;
 }
 
-export async function getManyMatchScratchpads<T extends MatchScratchpad>(
+export async function getManyMatchScratchpads<T extends BaseMatchScratchpad>(
   ids: string[]
 ): Promise<Record<string, T>> {
   const values = await getMany<T>(ids);
   return Object.fromEntries(ids.map((id, i) => [id, values[i]!]));
 }
 
-export async function setMatchScratchpad(
+export async function setMatchScratchpad<T extends BaseMatchScratchpad>(
   id: string,
-  scratchpad: MatchScratchpad
+  scratchpad: T
 ) {
   await update<Set<string>>(
     `scratchpad_${scratchpad.event}_idx`,
-    (old) => old?.add(id) ?? new Set(id)
+    (old) => old?.add(id) ?? new Set([id])
   );
   return set(id, scratchpad);
 }
@@ -51,8 +51,8 @@ export async function getScratchpadIdsForEvent(sku: string) {
   return data ?? new Set();
 }
 
-export async function setManyMatchScratchpad(
-  entries: [id: string, scratchpad: MatchScratchpad][]
+export async function setManyMatchScratchpad<T extends BaseMatchScratchpad>(
+  entries: [id: string, scratchpad: T][]
 ) {
   return setMany(entries);
 }
@@ -61,7 +61,7 @@ export async function editScratchpad<T extends MatchScratchpad>(
   id: string,
   scratchpad: EditScratchpad<T>
 ) {
-  const current = await getMatchScratchpad(id);
+  const current = await getMatchScratchpad<T>(id);
 
   if (!current) {
     return;

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -1,4 +1,4 @@
-import { del, get, set } from "idb-keyval";
+import { del, get, set } from "~utils/data/keyval";
 import type {
   ShareResponse,
   ShareUser,

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -16,7 +16,7 @@ import type {
   APIPutInvitationRequestResponseBody,
   APIGetInvitationRequestResponseBody,
 } from "~share/api";
-import { IncidentWithID } from "./incident";
+import { Incident } from "./incident";
 import { queryClient } from "./query";
 import { exportPublicKey, getKeyPair, getSignRequestHeaders } from "./crypto";
 
@@ -277,7 +277,7 @@ export async function getShareData(
 }
 
 export async function addServerIncident(
-  incident: IncidentWithID
+  incident: Incident
 ): Promise<ShareResponse<APIPutIncidentResponseBody>> {
   const url = new URL(`/api/${incident.event}/incident`, URL_BASE);
 
@@ -289,7 +289,7 @@ export async function addServerIncident(
 }
 
 export async function editServerIncident(
-  incident: IncidentWithID
+  incident: Incident
 ): Promise<ShareResponse<APIPatchIncidentResponseBody>> {
   const url = new URL(`/api/${incident.event}/incident`, URL_BASE);
 

--- a/src/utils/hooks/history.ts
+++ b/src/utils/hooks/history.ts
@@ -2,7 +2,7 @@
  * Stores recent events
  **/
 
-import { get, set } from "idb-keyval";
+import { get, set } from "~utils/data/keyval";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { EventData } from "robotevents/out/endpoints/events";
 import { Rule } from "./rules";

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -15,6 +15,7 @@ import {
 } from "@tanstack/react-query";
 import { Alliance, Match, MatchData } from "robotevents/out/endpoints/matches";
 import { toast } from "~components/Toast";
+import { useShareConnection } from "~models/ShareConnection";
 import { queryClient } from "~utils/data/query";
 
 export function useIncident(id: string | undefined | null) {
@@ -44,11 +45,13 @@ export function useEventIncidents(sku: string | undefined | null) {
 }
 
 export function useNewIncident() {
+  const connection = useShareConnection();
   return useMutation({
     mutationKey: ["newIncident"],
     mutationFn: async (incident: Omit<Incident, "id">) => {
       try {
         const id = await newIncident(incident);
+        connection.addIncident({ id, ...incident });
         return id;
       } catch (e) {
         toast({ type: "error", message: `${e}` });
@@ -60,12 +63,14 @@ export function useNewIncident() {
   });
 }
 
-export function useEditIncident(updateRemote?: boolean) {
+export function useEditIncident() {
+  const connection = useShareConnection();
   return useMutation({
     mutationKey: ["editIncident"],
     mutationFn: async (incident: Omit<Incident, "event" | "team">) => {
       try {
-        await editIncident(incident.id, incident, updateRemote);
+        const updated = await editIncident(incident.id, incident);
+        connection.editIncident(updated!);
         return incident;
       } catch (e) {
         toast({ type: "error", message: `${e}` });
@@ -77,12 +82,14 @@ export function useEditIncident(updateRemote?: boolean) {
   });
 }
 
-export function useDeleteIncident(updateRemote?: boolean) {
+export function useDeleteIncident() {
+  const connection = useShareConnection();
   return useMutation({
     mutationKey: ["deleteIncident"],
     mutationFn: async (id: string) => {
       try {
-        await deleteIncident(id, updateRemote);
+        await deleteIncident(id);
+        connection.deleteIncident(id);
       } catch (e) {
         toast({ type: "error", message: `${e}` });
       }

--- a/src/utils/hooks/incident.ts
+++ b/src/utils/hooks/incident.ts
@@ -1,6 +1,5 @@
 import {
   Incident,
-  IncidentWithID,
   deleteIncident,
   editIncident,
   getIncident,
@@ -32,7 +31,7 @@ export function useIncident(id: string | undefined | null) {
 }
 
 export function useEventIncidents(sku: string | undefined | null) {
-  return useQuery<IncidentWithID[]>({
+  return useQuery<Incident[]>({
     queryKey: ["incidents", "event", sku],
     queryFn: async () => {
       if (!sku) {
@@ -47,7 +46,7 @@ export function useEventIncidents(sku: string | undefined | null) {
 export function useNewIncident() {
   return useMutation({
     mutationKey: ["newIncident"],
-    mutationFn: async (incident: Incident) => {
+    mutationFn: async (incident: Omit<Incident, "id">) => {
       try {
         const id = await newIncident(incident);
         return id;
@@ -64,7 +63,7 @@ export function useNewIncident() {
 export function useEditIncident(updateRemote?: boolean) {
   return useMutation({
     mutationKey: ["editIncident"],
-    mutationFn: async (incident: Omit<IncidentWithID, "event" | "team">) => {
+    mutationFn: async (incident: Omit<Incident, "event" | "team">) => {
       try {
         await editIncident(incident.id, incident, updateRemote);
         return incident;
@@ -102,7 +101,7 @@ export function usePendingIncidents(
       mutationKey: ["newIncident"],
       status: "pending",
     },
-    select: (mutation) => mutation.state.variables as IncidentWithID,
+    select: (mutation) => mutation.state.variables as Incident,
   });
 
   const editIncident = useMutationState({
@@ -110,7 +109,7 @@ export function usePendingIncidents(
       mutationKey: ["editIncident"],
       status: "pending",
     },
-    select: (mutation) => mutation.state.variables as IncidentWithID,
+    select: (mutation) => mutation.state.variables as Incident,
   });
 
   const deleteIncident = useMutationState({
@@ -129,7 +128,7 @@ export function usePendingIncidents(
 }
 
 export function useTeamIncidents(team: string | undefined | null) {
-  return useQuery<IncidentWithID[]>({
+  return useQuery<Incident[]>({
     queryKey: ["incidents", "team", team],
     queryFn: () => {
       if (!team) {
@@ -145,7 +144,7 @@ export function useTeamIncidentsByEvent(
   team: string | undefined | null,
   sku: string | undefined | null
 ) {
-  return useQuery<IncidentWithID[]>({
+  return useQuery<Incident[]>({
     queryKey: ["incidents", "team", team, "event", sku],
     queryFn: async () => {
       if (!team || !sku) {
@@ -166,7 +165,7 @@ export function useTeamIncidentsByEvent(
 
 export type TeamIncidentsByMatch = {
   team: string;
-  incidents: IncidentWithID[];
+  incidents: Incident[];
 }[];
 
 export function useTeamIncidentsByMatch(

--- a/src/utils/hooks/scratchpad.ts
+++ b/src/utils/hooks/scratchpad.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { MatchData } from "robotevents/out/endpoints/matches";
+import { EditScratchpad, MatchScratchpad } from "~share/MatchScratchpad";
+import {
+  editScratchpad,
+  getDefaultScratchpad,
+  getGameForSeason,
+  getMatchScratchpad,
+  setMatchScratchpad,
+} from "~utils/data/scratchpad";
+import { useEvent } from "./robotevents";
+import { getSender } from "~utils/data/share";
+import { useSender } from "./share";
+import { queryClient } from "~utils/data/query";
+
+export function useMatchScratchpad<T extends MatchScratchpad>(
+  match?: MatchData | null
+) {
+  return useQuery({
+    queryKey: ["scratchpad", match],
+    queryFn: async () => {
+      if (!match) {
+        return null;
+      }
+
+      const scratchpad = await getMatchScratchpad<T>(match);
+      return scratchpad ?? null;
+    },
+  });
+}
+
+export function useDefaultScratchpad<T extends MatchScratchpad>(
+  match?: MatchData
+) {
+  const { data: event, isSuccess: isSuccessEvent } = useEvent(
+    match?.event.code ?? ""
+  );
+  const { data: sender, isSuccess: isSuccessSender } = useSender();
+  return useQuery({
+    queryKey: ["default_match_scratchpad", event?.season.id, sender],
+    queryFn: () => {
+      if (!event || !sender || !match) {
+        return null;
+      }
+
+      const game = getGameForSeason(event.season.id);
+      if (!game) {
+        return null;
+      }
+
+      return getDefaultScratchpad(match, sender, game) as T;
+    },
+    enabled: isSuccessEvent && isSuccessSender,
+  });
+}
+
+export function useUpdateMatchScratchpad<T extends MatchScratchpad>(
+  match?: MatchData
+) {
+  const { data: event } = useEvent(match?.event.code ?? "");
+
+  return useMutation({
+    mutationKey: ["update_match_scratchpad", match],
+    mutationFn: async (scratchpad: EditScratchpad<T>) => {
+      if (!match || !event) {
+        return null;
+      }
+
+      const game = getGameForSeason(event.season.id);
+      if (!game) {
+        return null;
+      }
+
+      const current = await getMatchScratchpad(match);
+      if (!current) {
+        const sender = await getSender();
+        const def = getDefaultScratchpad(match, sender, game);
+        await setMatchScratchpad(match, def);
+      }
+
+      await editScratchpad(match, scratchpad);
+      queryClient.invalidateQueries({
+        exact: true,
+        queryKey: [`scratchpad`, match],
+      });
+    },
+  });
+}

--- a/src/utils/hooks/share.ts
+++ b/src/utils/hooks/share.ts
@@ -6,6 +6,7 @@ import {
   acceptEventInvitation,
   createInstance,
   getEventInvitation,
+  getSender,
   getShareId,
   getShareName,
   registerUser,
@@ -39,6 +40,13 @@ export function useShareID() {
   return useQuery({
     queryKey: ["share_id"],
     queryFn: () => getShareId(),
+  });
+}
+
+export function useSender() {
+  return useQuery({
+    queryKey: ["sender"],
+    queryFn: () => getSender(),
   });
 }
 

--- a/src/utils/hooks/share.ts
+++ b/src/utils/hooks/share.ts
@@ -1,4 +1,4 @@
-import { set } from "idb-keyval";
+import { set } from "~utils/data/keyval";
 import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { queryClient } from "~utils/data/query";

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,24 @@
+export function timeAgo(input: Date) {
+  const date = new Date(input);
+  const formatter = new Intl.RelativeTimeFormat("en");
+  const ranges = {
+    years: 3600 * 24 * 365,
+    months: 3600 * 24 * 30,
+    weeks: 3600 * 24 * 7,
+    days: 3600 * 24,
+    hours: 3600,
+    minutes: 60,
+    seconds: 1,
+  };
+  const secondsElapsed = (date.getTime() - Date.now()) / 1000;
+  for (const [key, value] of Object.entries(ranges)) {
+    if (value < Math.abs(secondsElapsed)) {
+      const delta = secondsElapsed / value;
+      return formatter.format(
+        Math.round(delta),
+        key as Intl.RelativeTimeFormatUnit
+      );
+    }
+  }
+  return formatter.format(-1, "seconds");
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/worker/types/EventIncidents.d.ts
+++ b/worker/types/EventIncidents.d.ts
@@ -1,22 +1,6 @@
-import { WebSocketSender } from "./api";
+import { WithRevision } from "./revision";
 
 export type UnchangeableProperties = "revision" | "event" | "team";
-
-type RevisionMap = {
-  [K in keyof Omit<Incident, UnchangeableProperties>]-?: {
-    property: K;
-    old: Incident[K];
-    new: Incident[K];
-  };
-};
-type Revision = RevisionMap[keyof RevisionMap];
-
-export type ChangeLog = {
-  user: WebSocketSender;
-  date: Date;
-  changes: Revision[];
-};
-
 export type IncidentOutcome = "Minor" | "Major" | "Disabled" | "General";
 
 export type IncidentMatchHeadToHead = {
@@ -34,26 +18,23 @@ export type IncidentMatchSkills = {
 
 export type IncidentMatch = IncidentMatchHeadToHead | IncidentMatchSkills;
 
-export type Incident = {
-  id: string;
+export type Incident = WithRevision<
+  {
+    id: string;
 
-  time: Date;
+    time: Date;
 
-  event: string; // SKU
+    event: string; // SKU
 
-  match?: IncidentMatch;
-  team: string; // team number
+    match?: IncidentMatch;
+    team: string; // team number
 
-  revision?: {
-    count: number;
-    user: WebSocketSender;
-    history: ChangeLog[];
-  };
-
-  outcome: IncidentOutcome;
-  rules: string[];
-  notes: string;
-};
+    outcome: IncidentOutcome;
+    rules: string[];
+    notes: string;
+  },
+  UnchangeableProperties
+>;
 
 type EditIncident = Omit<Incident, UnchangeableProperties>;
 

--- a/worker/types/MatchScratchpad.d.ts
+++ b/worker/types/MatchScratchpad.d.ts
@@ -18,19 +18,23 @@ export type BaseMatchScratchpad = {
   notes: string;
 };
 
+export type HighStakesMatchScratchpadProperties = {
+  game: "High Stakes";
+  awp: Record<Color, boolean>;
+  auto: Color | "tie" | "none";
+};
+
 export type HighStakesMatchScratchpad = WithRevision<
-  BaseMatchScratchpad & {
-    game: "High Stakes";
-    awp: Record<Color, boolean>;
-    auto: Color | "tie" | "none";
-  },
+  BaseMatchScratchpad & HighStakesMatchScratchpadProperties,
   UnchangeableProperties
 >;
 
+export type RapidRelayMatchScratchpadProperties = {
+  game: "Rapid Relay";
+};
+
 export type RapidRelayMatchScratchpad = WithRevision<
-  BaseMatchScratchpad & {
-    game: "Rapid Relay";
-  },
+  BaseMatchScratchpad & RapidRelayMatchScratchpadProperties,
   UnchangeableProperties
 >;
 

--- a/worker/types/MatchScratchpad.d.ts
+++ b/worker/types/MatchScratchpad.d.ts
@@ -1,0 +1,44 @@
+import { IncidentMatchHeadToHead } from "./EventIncidents";
+import { WithRevision } from "./revision";
+import { Color } from "robotevents/out/endpoints/matches";
+
+export type UnchangeableProperties = "event" | "match" | "revision" | "game";
+
+export type SupportedGame = "High Stakes" | "Rapid Relay";
+
+export type ScratchpadForGame = {
+  [SupportedGame.HighStakes]: HighStakesMatchScratchpad;
+  [SupportedGame.RapidRelay]: RapidRelayMatchScratchpad;
+};
+
+export type BaseMatchScratchpad = {
+  game: SupportedGame;
+  event: string;
+  match: IncidentMatchHeadToHead;
+  notes: string;
+};
+
+export type HighStakesMatchScratchpad = WithRevision<
+  BaseMatchScratchpad & {
+    game: "High Stakes";
+    awp: Record<Color, boolean>;
+    auto: Color | "tie" | "none";
+  },
+  UnchangeableProperties
+>;
+
+export type RapidRelayMatchScratchpad = WithRevision<
+  BaseMatchScratchpad & {
+    game: "Rapid Relay";
+  },
+  UnchangeableProperties
+>;
+
+export type MatchScratchpad =
+  | HighStakesMatchScratchpad
+  | RapidRelayMatchScratchpad;
+
+export type EditScratchpad<T extends MatchScratchpad> = Omit<
+  T,
+  UnchangeableProperties
+>;

--- a/worker/types/api.d.ts
+++ b/worker/types/api.d.ts
@@ -1,4 +1,5 @@
 import { EventIncidentsData, Incident, ShareUser } from "./EventIncidents";
+import { MatchScratchpad } from "./MatchScratchpad";
 import { Invitation, User } from "./server";
 
 export * from "./EventIncidents";
@@ -88,6 +89,12 @@ export type WebSocketRemoveIncidentMessage = {
   id: string;
 };
 
+export type WebSocketUpdateScratchpadMessage = {
+  type: "scratchpad_update";
+  id: string;
+  scratchpad: MatchScratchpad;
+};
+
 export type WebSocketBroadcastMessage = {
   type: "message";
   message: string;
@@ -97,6 +104,7 @@ export type WebSocketPeerMessage =
   | WebSocketAddIncidentMessage
   | WebSocketUpdateIncidentMessage
   | WebSocketRemoveIncidentMessage
+  | WebSocketUpdateScratchpadMessage
   | WebSocketBroadcastMessage;
 
 export type InvitationListItem = Pick<Invitation, "admin"> & {
@@ -108,6 +116,7 @@ export type WebSocketServerShareInfoMessage = {
   data: EventIncidentsData;
   activeUsers: ShareUser[];
   invitations: InvitationListItem[];
+  scratchpads: Record<string, MatchScratchpad>;
 };
 
 export type WebsocketServerUserAddMessage = {

--- a/worker/types/revision.d.ts
+++ b/worker/types/revision.d.ts
@@ -1,0 +1,25 @@
+import { WebSocketSender } from "./api";
+
+type ChangeMap<T, U> = {
+  [K in keyof Omit<T, U>]-?: {
+    property: K;
+    old: T[K];
+    new: T[K];
+  };
+};
+
+type Change<T, U> = ChangeMap<T, U>[keyof ChangeMap<T, U>];
+
+export type ChangeLog<T, U> = {
+  user: WebSocketSender;
+  date: Date;
+  changes: Change<T, U>[];
+};
+
+export type Revision<T, U> = {
+  user: WebSocketSender;
+  count: number;
+  history: ChangeLog<T, U>[];
+};
+
+export type WithRevision<T, U> = T & { revision?: Revision<T, U> };


### PR DESCRIPTION
Introduces the feature of "scratchpads," collaborative, real-time data elements attached to matches. The purpose of a scratchpad is to allow the Head Referee to record key details about a match and reference them later.

The first scratchpad enables users to record AWP and Auto Winners in matches.

It also includes a massive performance optimization to the `server_share_info` handler, improving performance by up to 50x on larger instances and massively reducing the chance of errors.