### PR TITLE
Support ADC 2024-2025

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4790,9 +4790,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001617",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+      "version": "1.0.30001679",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz",
+      "integrity": "sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4806,7 +4806,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/capnp-ts": {
       "version": "0.7.0",

--- a/public/rules/ADC/2024-2025.json
+++ b/public/rules/ADC/2024-2025.json
@@ -5,6 +5,168 @@
   "season": "2024-2025",
   "ruleGroups": [
     {
+      "name": "Teamwork Mission Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<TM1>",
+          "description": "Drop Zone Top Cleared.",
+          "link": "https://online.flippingbook.com/view/201482508/33/"
+        },
+        {
+          "rule": "<TM2>",
+          "description": "Bean Bag on Drop Zone",
+          "link": "https://online.flippingbook.com/view/201482508/33/"
+        },
+        {
+          "rule": "<TM3>",
+          "description": "Ball in Scoring Zone.",
+          "link": "https://online.flippingbook.com/view/201482508/35/"
+        },
+        {
+          "rule": "<TM4>",
+          "description": "Land on Small or Large Landing Cube.",
+          "link": "https://online.flippingbook.com/view/201482508/35/"
+        },
+        {
+          "rule": "<TM5>",
+          "description": "Land on a Landing Pad.",
+          "link": "https://online.flippingbook.com/view/201482508/36/"
+        },
+        {
+          "rule": "<TM6>",
+          "description": "Land on the bullseye.",
+          "link": "https://online.flippingbook.com/view/201482508/36/"
+        },
+        {
+          "rule": "<TM7>",
+          "description": "Drone starting position.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM8>",
+          "description": "Pilot Station.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM9>",
+          "description": "Visual Observer Station.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM10>",
+          "description": "Teams must clearly identify their Team color during a Match.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM11>",
+          "description": "Loading MatchLoad Balls at the Loading Station.",
+          "link": "https://online.flippingbook.com/view/201482508/38/"
+        },
+        {
+          "rule": "<TM12>",
+          "description": "Keep balls on the ramp and in the track.",
+          "link": "https://online.flippingbook.com/view/201482508/38/"
+        },
+        {
+          "rule": "<TM13>",
+          "description": "Only One Drone per Landing Field Element.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM14>",
+          "description": "Qualification will occur according to the official Match Schedule.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM15>",
+          "description": "Be at your Match on time.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM16>",
+          "description": "Each Team will be scheduled for at least 4 Qualification Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM17>",
+          "description": "Teams are ranked by their average qualification Match scores.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM18>",
+          "description": "The Alliance Selection process forms 2-Team Alliances for the Elimination Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM19>",
+          "description": "Send a Team representative to Alliance Selection.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM20>",
+          "description": "Each Team may only be invited once to join an Alliance.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM21>",
+          "description": "Number of Alliances for Elimination Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/41/"
+        },
+        {
+          "rule": "<TM22>",
+          "description": "Elimination Matches are played sequentially in rounds.",
+          "link": "https://online.flippingbook.com/view/201482508/41/"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Teams may only fly their drone in a designated Flight Zone.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Teams must pass Flight Clearance Inspection and use Pre Flight Checklist at competitions.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S3>",
+          "description": "Stay in the Pilot station or Visual Observer stations and out of the field during a Match.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S4>",
+          "description": "Stay in control of your Drone.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S5>",
+          "description": "Batteries must be charged before launch.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S6>",
+          "description": "Wear safety glasses.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S7>",
+          "description": "Students must be accompanied by an Adult.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S8>",
+          "description": "Additional Safety Practices.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        }
+      ]
+    }
+    {
       "name": "General Rules",
       "programs": ["ADC"],
       "rules": [
@@ -443,52 +605,6 @@
           "rule": "<D7>",
           "description": "There is a difference between accidentally and willfully violating a Drone rule.",
           "link": "https://online.flippingbook.com/view/201482508/60/"
-        }
-      ]
-    },
-    {
-      "name": "Safety Rules",
-      "programs": ["ADC"],
-      "rules": [
-        {
-          "rule": "<S1>",
-          "description": "Teams may only fly their drone in a designated Flight Zone.",
-          "link": "https://online.flippingbook.com/view/201482508/62/"
-        },
-        {
-          "rule": "<S2>",
-          "description": "Teams must pass Flight Clearance Inspection and use Pre Flight Checklist at competitions.",
-          "link": "https://online.flippingbook.com/view/201482508/62/"
-        },
-        {
-          "rule": "<S3>",
-          "description": "Stay in the Pilot station or Visual Observer stations and out of the field during a Match.",
-          "link": "https://online.flippingbook.com/view/201482508/62/"
-        },
-        {
-          "rule": "<S4>",
-          "description": "Stay in control of your Drone.",
-          "link": "https://online.flippingbook.com/view/201482508/62/"
-        },
-        {
-          "rule": "<S5>",
-          "description": "Batteries must be charged before launch.",
-          "link": "https://online.flippingbook.com/view/201482508/63/"
-        },
-        {
-          "rule": "<S6>",
-          "description": "Wear safety glasses.",
-          "link": "https://online.flippingbook.com/view/201482508/63/"
-        },
-        {
-          "rule": "<S7>",
-          "description": "Students must be accompanied by an Adult.",
-          "link": "https://online.flippingbook.com/view/201482508/63/"
-        },
-        {
-          "rule": "<S8>",
-          "description": "Additional Safety Practices.",
-          "link": "https://online.flippingbook.com/view/201482508/63/"
         }
       ]
     }

--- a/public/rules/ADC/2024-2025.json
+++ b/public/rules/ADC/2024-2025.json
@@ -1,0 +1,496 @@
+{
+  "$schema": "https://referee.fyi/rules/schema.json",
+  "title": "Mission 2025: Gravity",
+  "programs": ["ADC"],
+  "season": "2024-2025",
+  "ruleGroups": [
+    {
+      "name": "General Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<G1>",
+          "description": "Treat everyone with respect",
+          "link": "https://online.flippingbook.com/view/201482508/24/"
+        },
+        {
+          "rule": "<G2>",
+          "description": "The Aerial Drone Competition is a Student-centered program.",
+          "link": "https://online.flippingbook.com/view/201482508/24/"
+        },
+        {
+          "rule": "<G3>",
+          "description": "Use common sense",
+          "link": "https://online.flippingbook.com/view/201482508/26/"
+        },
+        {
+          "rule": "<G4>",
+          "description": "Piloting and Autonomous Flight skills must represent the skill level of the Team.",
+          "link": "https://online.flippingbook.com/view/201482508/26/"
+        },
+        {
+          "rule": "<G5>",
+          "description": "Drones at the field must be ready to fly.",
+          "link": "https://online.flippingbook.com/view/201482508/27/"
+        },
+        {
+          "rule": "<G7>",
+          "description": "During a Match, Flight Team Members may retrieve their Drone for troubleshooting if the Drone has not completed take off.",
+          "link": "https://online.flippingbook.com/view/201482508/27/"
+        },
+        {
+          "rule": "<G8>",
+          "description": "Be prepared for field minor variances.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        },
+        {
+          "rule": "<G9>",
+          "description": "Match replays are allowed, but rare.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        },
+        {
+          "rule": "<G10>",
+          "description": "No electronic communication devices allowed.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        },
+        {
+          "rule": "<G11>",
+          "description": "Flight Team Members may not stand on objects.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        },
+        {
+          "rule": "<G12>",
+          "description": "The Q&A system is an extension of this competition manual.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        },
+        {
+          "rule": "<G13>",
+          "description": "Only registered Teams may compete in an Aerial Drone Competition.",
+          "link": "https://online.flippingbook.com/view/201482508/28/"
+        }
+      ]
+    },
+    {
+      "name": "Tournament Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<T1>",
+          "description": "The Head Referee has ultimate authority on ruling decisions during the Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/29/"
+        },
+        {
+          "rule": "<T2>",
+          "description": "Head Referees must be qualified.",
+          "link": "https://online.flippingbook.com/view/201482508/29/"
+        },
+        {
+          "rule": "<T3>",
+          "description": "The Flight Team Members are permitted to immediately appeal the Head Referee’s ruling.",
+          "link": "https://online.flippingbook.com/view/201482508/30/"
+        },
+        {
+          "rule": "<T4>",
+          "description": "It’s not over until it’s over.",
+          "link": "https://online.flippingbook.com/view/201482508/30/"
+        },
+        {
+          "rule": "<T5>",
+          "description": "Flooring must be the same.",
+          "link": "https://online.flippingbook.com/view/201482508/30/"
+        },
+        {
+          "rule": "<T6>",
+          "description": "Division Finals",
+          "link": "https://online.flippingbook.com/view/201482508/30/"
+        }
+      ]
+    },
+    {
+      "name": "Teamwork Mission Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<TM1>",
+          "description": "Drop Zone Top Cleared.",
+          "link": "https://online.flippingbook.com/view/201482508/33/"
+        },
+        {
+          "rule": "<TM2>",
+          "description": "Bean Bag on Drop Zone",
+          "link": "https://online.flippingbook.com/view/201482508/33/"
+        },
+        {
+          "rule": "<TM3>",
+          "description": "Ball in Scoring Zone.",
+          "link": "https://online.flippingbook.com/view/201482508/35/"
+        },
+        {
+          "rule": "<TM4>",
+          "description": "Land on Small or Large Landing Cube.",
+          "link": "https://online.flippingbook.com/view/201482508/35/"
+        },
+        {
+          "rule": "<TM5>",
+          "description": "Land on a Landing Pad.",
+          "link": "https://online.flippingbook.com/view/201482508/36/"
+        },
+        {
+          "rule": "<TM6>",
+          "description": "Land on the bullseye.",
+          "link": "https://online.flippingbook.com/view/201482508/36/"
+        },
+        {
+          "rule": "<TM7>",
+          "description": "Drone starting position.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM8>",
+          "description": "Pilot Station.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM9>",
+          "description": "Visual Observer Station.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM10>",
+          "description": "Teams must clearly identify their Team color during a Match.",
+          "link": "https://online.flippingbook.com/view/201482508/37/"
+        },
+        {
+          "rule": "<TM11>",
+          "description": "Loading MatchLoad Balls at the Loading Station.",
+          "link": "https://online.flippingbook.com/view/201482508/38/"
+        },
+        {
+          "rule": "<TM12>",
+          "description": "Keep balls on the ramp and in the track.",
+          "link": "https://online.flippingbook.com/view/201482508/38/"
+        },
+        {
+          "rule": "<TM13>",
+          "description": "Only One Drone per Landing Field Element.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM14>",
+          "description": "Qualification will occur according to the official Match Schedule.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM15>",
+          "description": "Be at your Match on time.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM16>",
+          "description": "Each Team will be scheduled for at least 4 Qualification Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM17>",
+          "description": "Teams are ranked by their average qualification Match scores.",
+          "link": "https://online.flippingbook.com/view/201482508/39/"
+        },
+        {
+          "rule": "<TM18>",
+          "description": "The Alliance Selection process forms 2-Team Alliances for the Elimination Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM19>",
+          "description": "Send a Team representative to Alliance Selection.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM20>",
+          "description": "Each Team may only be invited once to join an Alliance.",
+          "link": "https://online.flippingbook.com/view/201482508/40/"
+        },
+        {
+          "rule": "<TM21>",
+          "description": "Number of Alliances for Elimination Matches.",
+          "link": "https://online.flippingbook.com/view/201482508/41/"
+        },
+        {
+          "rule": "<TM22>",
+          "description": "Elimination Matches are played sequentially in rounds.",
+          "link": "https://online.flippingbook.com/view/201482508/41/"
+        }
+      ]
+    },
+    {
+      "name": "Autonomous Flight Skills Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<AM1>",
+          "description": "Set up Color Mats.",
+          "link": "https://online.flippingbook.com/view/201482508/43/"
+        },
+        {
+          "rule": "<AM2>",
+          "description": "Take off.",
+          "link": "https://online.flippingbook.com/view/201482508/45/"
+        },
+        {
+          "rule": "<AM3>",
+          "description": "Identify the color of a Color Mat.",
+          "link": "https://online.flippingbook.com/view/201482508/45/"
+        },
+        {
+          "rule": "<AM4>",
+          "description": "Complete a figure 8.",
+          "link": "https://online.flippingbook.com/view/201482508/45/"
+        },
+        {
+          "rule": "<AM5>",
+          "description": "Fly under Arch Gate.",
+          "link": "https://online.flippingbook.com/view/201482508/47/"
+        },
+        {
+          "rule": "<AM6>",
+          "description": "Fly through the Small Hole.",
+          "link": "https://online.flippingbook.com/view/201482508/47/"
+        },
+        {
+          "rule": "<AM7>",
+          "description": "Fly through the Large Hole.",
+          "link": "https://online.flippingbook.com/view/201482508/48/"
+        },
+        {
+          "rule": "<AM8>",
+          "description": "Fly through the Keyhole Gate.",
+          "link": "https://online.flippingbook.com/view/201482508/48/"
+        },
+        {
+          "rule": "<AM9>",
+          "description": "Land on the Landing Pad.",
+          "link": "https://online.flippingbook.com/view/201482508/49/"
+        },
+        {
+          "rule": "<AM10>",
+          "description": "Land on Landing Cube.",
+          "link": "https://online.flippingbook.com/view/201482508/49/"
+        },
+        {
+          "rule": "<AM11>",
+          "description": "Autonomous means “no humans.”",
+          "link": "https://online.flippingbook.com/view/201482508/50/"
+        },
+        {
+          "rule": "<AM12>",
+          "description": "5 Minute Timer.",
+          "link": "https://online.flippingbook.com/view/201482508/50/"
+        },
+        {
+          "rule": "<AM13>",
+          "description": "Drone starting position.",
+          "link": "https://online.flippingbook.com/view/201482508/50/"
+        },
+        {
+          "rule": "<AM14>",
+          "description": "Pilot Station",
+          "link": "https://online.flippingbook.com/view/201482508/51/"
+        },
+        {
+          "rule": "<AM15>",
+          "description": "Visual Observer Station",
+          "link": "https://online.flippingbook.com/view/201482508/51/"
+        }
+      ]
+    },
+    {
+      "name": "Piloting Skills Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<PM1>",
+          "description": "Take off.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM2>",
+          "description": "Complete a figure 8.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM3>",
+          "description": "Fly through the Small Hole.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM4>",
+          "description": "Fly through the Large Hole.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM5>",
+          "description": "Fly through the Keyhole Gate.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM6>",
+          "description": "Land on the Landing Pad.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM7>",
+          "description": "Landing on the Landing Cube.",
+          "link": "https://online.flippingbook.com/view/201482508/55/"
+        },
+        {
+          "rule": "<PM8>",
+          "description": "Flight path.",
+          "link": "https://online.flippingbook.com/view/201482508/56/"
+        },
+        {
+          "rule": "<PM9>",
+          "description": "Drone starting position.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM10>",
+          "description": "Pilot station.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM11>",
+          "description": "Visual Observer Station.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM12>",
+          "description": "Piloting Skills Mission schedule.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM13>",
+          "description": "Autonomous Flight and Piloting Skills Mission rankings.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM14>",
+          "description": "Autonomous Flight and Piloting Skills Mission scores at leagues.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        },
+        {
+          "rule": "<PM15>",
+          "description": "Additional Flight and Piloting Skills Global rankings.",
+          "link": "https://online.flippingbook.com/view/201482508/57/"
+        }
+      ]
+    },
+    {
+      "name": "Specific Communication Mission Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<C1>",
+          "description": "All Teams must receive an interview",
+          "link": "https://online.flippingbook.com/view/201482508/59/"
+        },
+        {
+          "rule": "<C2>",
+          "description": "No Team may earn more than one judged award.",
+          "link": "https://online.flippingbook.com/view/201482508/59/"
+        },
+        {
+          "rule": "<C3>",
+          "description": "Judges must follow the criteria and award descriptions as presented in the Guide to Judging.",
+          "link": "https://online.flippingbook.com/view/201482508/59/"
+        }
+      ]
+    },
+    {
+      "name": "Drone Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<D1>",
+          "description": "Teams must use the CoDrone EDU, CoDrone EDU JROTC Edition or Parrot Mambo.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D2>",
+          "description": "Drones must utilize stock Drone electronics.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D3>",
+          "description": "Drones must utilize official motors, propellers and frames.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D4>",
+          "description": "Drones must be running current firmware.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D5>",
+          "description": "Decorations are allowed.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D6>",
+          "description": "One Drone at the Field.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        },
+        {
+          "rule": "<D7>",
+          "description": "There is a difference between accidentally and willfully violating a Drone rule.",
+          "link": "https://online.flippingbook.com/view/201482508/60/"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["ADC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Teams may only fly their drone in a designated Flight Zone.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Teams must pass Flight Clearance Inspection and use Pre Flight Checklist at competitions.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S3>",
+          "description": "Stay in the Pilot station or Visual Observer stations and out of the field during a Match.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S4>",
+          "description": "Stay in control of your Drone.",
+          "link": "https://online.flippingbook.com/view/201482508/62/"
+        },
+        {
+          "rule": "<S5>",
+          "description": "Batteries must be charged before launch.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S6>",
+          "description": "Wear safety glasses.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S7>",
+          "description": "Students must be accompanied by an Adult.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        },
+        {
+          "rule": "<S8>",
+          "description": "Additional Safety Practices.",
+          "link": "https://online.flippingbook.com/view/201482508/63/"
+        }
+      ]
+    }
+  ]
+}

--- a/public/rules/V5RC/2023-2024.json
+++ b/public/rules/V5RC/2023-2024.json
@@ -1,0 +1,777 @@
+{
+  "$schema": "https://referee.fyi/rules/schema.json",
+  "title": "Over Under",
+  "season": "2023-2024",
+  "programs": ["V5RC", "VURC", "VAIRC"],
+  "ruleGroups": [
+    {
+      "name": "Specific Game Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<SG1>",
+          "description": "Starting a Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG1.html"
+        },
+        {
+          "rule": "<SG2>",
+          "description": "Horizontal expansion is limited",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG2.html"
+        },
+        {
+          "rule": "<SG3>",
+          "description": "Keep Triballs in the field",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG3.html"
+        },
+        {
+          "rule": "<SG4>",
+          "description": "Each Robot gets one Alliance Triball as a Preload",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG4.html"
+        },
+        {
+          "rule": "<SG5>",
+          "description": "Stay away from nets on the Goals",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG5.html"
+        },
+        {
+          "rule": "<SG6>",
+          "description": "Match Load Triballs may be safely introduced during the Match under certain conditions",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG6.html"
+        },
+        {
+          "rule": "<SG7>",
+          "description": "Possession is limited to one (1) Triball",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG7.html"
+        },
+        {
+          "rule": "<SG8>",
+          "description": "Stay out of your opponent's Goal unless they are Double-Zoned",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG8.html"
+        },
+        {
+          "rule": "<SG9>",
+          "description": "Stay in your starting Zone during Autonomous",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG9.html"
+        },
+        {
+          "rule": "<SG10>",
+          "description": "Enter the Neutral Zone during Autonomous at your own risk",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG10.html"
+        },
+        {
+          "rule": "<SG11>",
+          "description": "Elevation is protected",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SG11.html"
+        }
+      ]
+    },
+    {
+      "name": "VAIRC General Rules",
+      "programs": ["VAIRC"],
+      "rules": [
+        {
+          "rule": "<VAIG1>",
+          "description": "All <VUGx>, <SCx>, and <Sx> rules apply as written",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIG1.html"
+        },
+        {
+          "rule": "<VAIG2>",
+          "description": "As noted by <G11>, Drive Team Members are not permitted to interact with their Robots in any way while they are operating autonomously (i",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIG2.html"
+        },
+        {
+          "rule": "<VAIG3>",
+          "description": "Just as VRC and VEX U Teams are responsible for the actions of their Robots during the Autonomous Period, VAIRC Teams are responsible for the actions of their Robots throughout the entirety of a VAIRC Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIG3.html"
+        },
+        {
+          "rule": "<VAIG4>",
+          "description": "This rule supersedes <SG8>",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIG4.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC General Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUG1>",
+          "description": "Different Starting Tiles",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG1.html"
+        },
+        {
+          "rule": "<VUG2>",
+          "description": "Different Preloads",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG2.html"
+        },
+        {
+          "rule": "<VUG3>",
+          "description": "Different Autonomous zones",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG3.html"
+        },
+        {
+          "rule": "<VUG4>",
+          "description": "Different Match Load introductions",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG4.html"
+        },
+        {
+          "rule": "<VUG5>",
+          "description": "Different Match Load availability",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG5.html"
+        },
+        {
+          "rule": "<VUG6>",
+          "description": "Different Autonomous Win Point",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUG6.html"
+        }
+      ]
+    },
+    {
+      "name": "General Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<G1>",
+          "description": "Treat everyone with respect",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G1.html"
+        },
+        {
+          "rule": "<G2>",
+          "description": "VRC is a student-centered program",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G2.html"
+        },
+        {
+          "rule": "<G3>",
+          "description": "Use common sense",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G3.html"
+        },
+        {
+          "rule": "<G4>",
+          "description": "The Robot must represent the skill level of the Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G4.html"
+        },
+        {
+          "rule": "<G5>",
+          "description": "Robots begin the Match in the starting volume",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G5.html"
+        },
+        {
+          "rule": "<G6>",
+          "description": "Keep your Robots together",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G6.html"
+        },
+        {
+          "rule": "<G7>",
+          "description": "Don't clamp your Robot to the field",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G7.html"
+        },
+        {
+          "rule": "<G8>",
+          "description": "Only Drivers, and only in the Alliance Station",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G8.html"
+        },
+        {
+          "rule": "<G9>",
+          "description": "Hands out of the field",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G9.html"
+        },
+        {
+          "rule": "<G10>",
+          "description": "Controllers must stay connected to the field",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G10.html"
+        },
+        {
+          "rule": "<G11>",
+          "description": "Autonomous means “no humans",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G11.html"
+        },
+        {
+          "rule": "<G12>",
+          "description": "All rules still apply in the Autonomous Period",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G12.html"
+        },
+        {
+          "rule": "<G13>",
+          "description": "Don't destroy other Robots",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G13.html"
+        },
+        {
+          "rule": "<G14>",
+          "description": "Offensive Robots get the “benefit of the doubt",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G14.html"
+        },
+        {
+          "rule": "<G15>",
+          "description": "You can't force an opponent into a penalty",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G15.html"
+        },
+        {
+          "rule": "<G16>",
+          "description": "No Holding for more than a 5-count",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G16.html"
+        },
+        {
+          "rule": "<G17>",
+          "description": "Use Triballs to play the game",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/G17.html"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Be safe out there",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/S1.html"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Students must be accompanied by an Adult",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/S2.html"
+        },
+        {
+          "rule": "<S3>",
+          "description": "Stay inside the field",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/S3.html"
+        },
+        {
+          "rule": "<S4>",
+          "description": "Wear safety glasses",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/S4.html"
+        }
+      ]
+    },
+    {
+      "name": "VAIRC Robot Rules",
+      "programs": ["VAIRC"],
+      "rules": [
+        {
+          "rule": "<VAIR1>",
+          "description": "All <VURx> rules apply as written",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIR1.html"
+        },
+        {
+          "rule": "<VAIR2>",
+          "description": "Any components used for AI vision processing, such as those found in the VEX AI kit (276-8983), are considered standard Additional Electronics and must abide by <VUR12> as-written",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIR2.html"
+        },
+        {
+          "rule": "<VAIR3>",
+          "description": "Although VAIRC Crossover Teams are encouraged to build separate Robots from their Base Team counterparts, it is not required",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIR3.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Robot Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUR1>",
+          "description": "Teams may use two (2) Robots in each Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR1.html"
+        },
+        {
+          "rule": "<VUR2>",
+          "description": "Teams may use any official VEX Robotics products, other than the exceptions listed in the tables below, to construct their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR2.html"
+        },
+        {
+          "rule": "<VUR3>",
+          "description": "Fabricated Parts may be made by applying the following manufacturing processes to legal Raw Stock:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR3.html"
+        },
+        {
+          "rule": "<VUR4>",
+          "description": "Fabricated Parts must be made from legal Raw Stock",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR4.html"
+        },
+        {
+          "rule": "<VUR5>",
+          "description": "The following material types are not considered Raw Stock, and are therefore not permitted:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR5.html"
+        },
+        {
+          "rule": "<VUR6>",
+          "description": "Fabricated Parts may not be made from Raw Stock which poses a safety or damage risk to the event, other Teams, or Field Elements",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR6.html"
+        },
+        {
+          "rule": "<VUR7>",
+          "description": "Fabricated Parts must be made by Team members",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR7.html"
+        },
+        {
+          "rule": "<VUR8>",
+          "description": "Teams may use commercially-available springs on their Robots",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR8.html"
+        },
+        {
+          "rule": "<VUR9>",
+          "description": "Teams may use commercially available fastener hardware on their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR9.html"
+        },
+        {
+          "rule": "<VUR10>",
+          "description": "Each Robot must utilize exactly one (1) V5 Robot Brain and up to two (2) V5 Robot Radios connected to a V5 Controller",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR10.html"
+        },
+        {
+          "rule": "<VUR11>",
+          "description": "There is no restriction on the number of V5 Smart Motors (11W) [276-4840] and/or EXP Smart Motors (5",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR11.html"
+        },
+        {
+          "rule": "<VUR12>",
+          "description": "There is no restriction on sensors and other Additional Electronics that Robots may use for sensing and processing, except as follows:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR12.html"
+        },
+        {
+          "rule": "<VUR13>",
+          "description": "Teams may utilize an unlimited amount of the following commercially available pneumatic components: cylinders, actuators, valves, gauges, storage tanks, regulators, manifolds, tubing, and solenoids",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR13.html"
+        },
+        {
+          "rule": "<VUR14>",
+          "description": "Teams may use commercially available bearings on their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUR14.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<R1>",
+          "description": "One Robot per Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R1.html"
+        },
+        {
+          "rule": "<R2>",
+          "description": "Robots must represent the Team's skill level",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R2.html"
+        },
+        {
+          "rule": "<R3>",
+          "description": "Robots must pass inspection",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R3.html"
+        },
+        {
+          "rule": "<R4>",
+          "description": "Robots must fit within an 18” x 18” x 18” volume",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R4.html"
+        },
+        {
+          "rule": "<R5>",
+          "description": "Robots must be safe",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R5.html"
+        },
+        {
+          "rule": "<R6>",
+          "description": "Robots are built from the VEX V5 system",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R6.html"
+        },
+        {
+          "rule": "<R7>",
+          "description": "Certain non-VEX components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R7.html"
+        },
+        {
+          "rule": "<R8>",
+          "description": "Decorations are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R8.html"
+        },
+        {
+          "rule": "<R9>",
+          "description": "Officially registered Team numbers must be displayed on Robot License Plates",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R9.html"
+        },
+        {
+          "rule": "<R10>",
+          "description": "Let go of Triballs after the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R10.html"
+        },
+        {
+          "rule": "<R11>",
+          "description": "Robots have one microcontroller",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R11.html"
+        },
+        {
+          "rule": "<R12>",
+          "description": "Motors are limited",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R12.html"
+        },
+        {
+          "rule": "<R13>",
+          "description": "Electrical power comes from VEX batteries only",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R13.html"
+        },
+        {
+          "rule": "<R14>",
+          "description": "No modifications to electronic or pneumatic components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R14.html"
+        },
+        {
+          "rule": "<R15>",
+          "description": "Most modifications to non-electrical components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R15.html"
+        },
+        {
+          "rule": "<R16>",
+          "description": "Robots use VEXnet",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R16.html"
+        },
+        {
+          "rule": "<R17>",
+          "description": "Give the radio some space",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R17.html"
+        },
+        {
+          "rule": "<R18>",
+          "description": "A limited amount of custom plastic is allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R18.html"
+        },
+        {
+          "rule": "<R19>",
+          "description": "A limited amount of tape is allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R19.html"
+        },
+        {
+          "rule": "<R20>",
+          "description": "Certain non-VEX fasteners are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R20.html"
+        },
+        {
+          "rule": "<R21>",
+          "description": "New VEX parts are legal",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R21.html"
+        },
+        {
+          "rule": "<R22>",
+          "description": "Pneumatics are limited",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R22.html"
+        },
+        {
+          "rule": "<R23>",
+          "description": "One or two Controllers per Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R23.html"
+        },
+        {
+          "rule": "<R24>",
+          "description": "Custom V5 Smart Cables are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R24.html"
+        },
+        {
+          "rule": "<R25>",
+          "description": "Keep the power button accessible",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R25.html"
+        },
+        {
+          "rule": "<R26>",
+          "description": "Use a “Competition Template” for programming",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R26.html"
+        },
+        {
+          "rule": "<R27>",
+          "description": "There is a difference between accidentally and willfully violating a Robot rule",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/R27.html"
+        }
+      ]
+    },
+    {
+      "name": "Scoring Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<SC1>",
+          "description": "All Scoring statuses are evaluated after the Match ends",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC1.html"
+        },
+        {
+          "rule": "<SC2>",
+          "description": "Scoring of the Autonomous Bonus is evaluated immediately after the Autonomous Period ends (i",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC2.html"
+        },
+        {
+          "rule": "<SC3>",
+          "description": "A Triball is considered Scored in a Goal if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC3.html"
+        },
+        {
+          "rule": "<SC4>",
+          "description": "A Triball is considered Scored in an Offensive Zone if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC4.html"
+        },
+        {
+          "rule": "<SC5>",
+          "description": "Alliance Triballs may be Scored in any Goal or Offensive Zone, and always count toward the same color Alliance as the Triball",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC5.html"
+        },
+        {
+          "rule": "<SC6>",
+          "description": "Elevation points are comparative, and are awarded based on the Elevation Tiers achieved by all Robots at the end of the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC6.html"
+        },
+        {
+          "rule": "<SC7>",
+          "description": "An Autonomous Win Point is awarded to any Alliance that ends the Autonomous Period with the following tasks completed:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/SC7.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Robot SKills Challenge Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VURS1>",
+          "description": "One Robot must start the Robot Skills Match in each set of Starting Tiles, as shown in Figure 42",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VURS1.html"
+        },
+        {
+          "rule": "<VURS2>",
+          "description": "The field is set up the same as a standard Robot Skills Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VURS2.html"
+        },
+        {
+          "rule": "<VURS3>",
+          "description": "The Elevation Tier scoring listed in rule <RSC5> is used for both Robots",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VURS3.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Skills Challenge Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<RSC1>",
+          "description": "All rules from “The Game” section of the manual apply to the Robot Skills Challenge, unless otherwise specified",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC1.html"
+        },
+        {
+          "rule": "<RSC2>",
+          "description": "Robots may start the Robot Skills Match on any legal Starting Tiles for either Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC2.html"
+        },
+        {
+          "rule": "<RSC3>",
+          "description": "Teams may utilize the forty-four (44) Match Load Triballs within the guidelines set forth by <SG5>",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC3.html"
+        },
+        {
+          "rule": "<RSC4>",
+          "description": "In Robot Skills Matches, Teams play as if they are on the red Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC4.html"
+        },
+        {
+          "rule": "<RSC5>",
+          "description": "Elevation points are awarded based on the Elevation Tier achieved by the Robot at the end of the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC5.html"
+        },
+        {
+          "rule": "<RSC6>",
+          "description": "There is no requirement that Skills Challenge fields have the same consistent modifications as the Head-to-Head fields",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC6.html"
+        },
+        {
+          "rule": "<RSC7>",
+          "description": "Triballs which come to rest on top of the red Goal may not be retrieved by a Drive Team Member or Referee during the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/RSC7.html"
+        }
+      ]
+    },
+    {
+      "name": "VAIRC Tournament Rules",
+      "programs": ["VAIRC"],
+      "rules": [
+        {
+          "rule": "<VAIT1>",
+          "description": "The following VEX U rules apply as written:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIT1.html"
+        },
+        {
+          "rule": "<VAIT2>",
+          "description": "VEX AI Robotics Competition Teams may consist of Students that fall into one of the following categories:",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIT2.html"
+        },
+        {
+          "rule": "<VAIT3>",
+          "description": "Students may only participate on one (1) VAIRC Team in a given season",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VAIT3.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Tournament Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUT1>",
+          "description": "Instead of a 2-Team Alliance format, VEX U Matches will be played 1-Team vs",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT1.html"
+        },
+        {
+          "rule": "<VUT2>",
+          "description": "Qualification Matches will be conducted in the same manner as in a VRC tournament, but in the revised 1v1 format described in <VUT1>",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT2.html"
+        },
+        {
+          "rule": "<VUT3>",
+          "description": "Elimination Matches will be conducted in the same manner as in a VRC tournament, but without an Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT3.html"
+        },
+        {
+          "rule": "<VUT4>",
+          "description": "The Autonomous Period at the beginning of each Head-to-Head Match will be 45 seconds (0:45)",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT4.html"
+        },
+        {
+          "rule": "<VUT5>",
+          "description": "The Driver Controlled Period is shortened to 75 seconds (1:15) and immediately follows the Autonomous Period",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT5.html"
+        },
+        {
+          "rule": "<VUT6>",
+          "description": "Each Robot is allowed up to three (3) Drive Team Members in the Alliance Station during a Match, as modified from <G8>",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT6.html"
+        },
+        {
+          "rule": "<VUT7>",
+          "description": "VEX U Student eligibility",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/VUT7.html"
+        }
+      ]
+    },
+    {
+      "name": "Tournament Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<T1>",
+          "description": "Head Referees have ultimate and final authority on all gameplay ruling decisions during the competition",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T1.html"
+        },
+        {
+          "rule": "<T2>",
+          "description": "Head Referees must be qualified",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T2.html"
+        },
+        {
+          "rule": "<T3>",
+          "description": "The Drive Team is permitted to immediately appeal a Head Referee's ruling",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T3.html"
+        },
+        {
+          "rule": "<T4>",
+          "description": "The Event Partner has ultimate authority regarding all non-gameplay decisions during an event",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T4.html"
+        },
+        {
+          "rule": "<T5>",
+          "description": "A Team's Robot and/or Drive Team Member should attend every Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T5.html"
+        },
+        {
+          "rule": "<T6>",
+          "description": "Robots at the field must be ready to play",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T6.html"
+        },
+        {
+          "rule": "<T7>",
+          "description": "Match replays are allowed, but rare",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T7.html"
+        },
+        {
+          "rule": "<T8>",
+          "description": "Disqualifications",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T8.html"
+        },
+        {
+          "rule": "<T9>",
+          "description": "Each Elimination Alliance gets one Time Out",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T9.html"
+        },
+        {
+          "rule": "<T10>",
+          "description": "Be prepared for minor field variance",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T10.html"
+        },
+        {
+          "rule": "<T11>",
+          "description": "Fields may be repaired at the Event Partner's discretion",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T11.html"
+        },
+        {
+          "rule": "<T12>",
+          "description": "The red Alliance places last",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T12.html"
+        },
+        {
+          "rule": "<T13>",
+          "description": "Qualification Matches follow the Match schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T13.html"
+        },
+        {
+          "rule": "<T14>",
+          "description": "Each Team will have at least six Qualification Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T14.html"
+        },
+        {
+          "rule": "<T15>",
+          "description": "Qualification Matches contribute to a Team's ranking for Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T15.html"
+        },
+        {
+          "rule": "<T16>",
+          "description": "Qualification Match tiebreakers",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T16.html"
+        },
+        {
+          "rule": "<T17>",
+          "description": "Send a Student representative to Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T17.html"
+        },
+        {
+          "rule": "<T18>",
+          "description": "Each Team may only be invited once to join one Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T18.html"
+        },
+        {
+          "rule": "<T19>",
+          "description": "Elimination Matches follow the Elimination Bracket",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T19.html"
+        },
+        {
+          "rule": "<T20>",
+          "description": "Elimination Matches are a blend of “Best of 1” and “Best of 3",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T20.html"
+        },
+        {
+          "rule": "<T21>",
+          "description": "Small tournaments may have fewer Alliances",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T21.html"
+        },
+        {
+          "rule": "<T22>",
+          "description": "Fields at an event must be consistent with each other",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T22.html"
+        },
+        {
+          "rule": "<T23>",
+          "description": "There are three types of field control that may be used: A VEXnet Field Controller controlled by Tournament Manager, which connects to a Controller's competition port via ethernet cable",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T23.html"
+        },
+        {
+          "rule": "<T24>",
+          "description": "There are two types of Field Perimeter that may be used: VEX Metal Competition Field Perimeter (SKU 278-1501) VEX Portable Competition Field Perimeter (SKU 276-8242) See Appendix A for more details",
+          "link": "https://www.robotevents.com/storage/game_manual/VRC_2023-2024_Over_Under/rules/T24.html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/rules/V5RC/2024-2025.json
+++ b/public/rules/V5RC/2024-2025.json
@@ -1,0 +1,719 @@
+{
+  "$schema": "https://referee.fyi/rules/schema.json",
+  "title": "High Stakes",
+  "season": "2024-2025",
+  "programs": ["V5RC", "VURC", "VAIRC"],
+  "ruleGroups": [
+    {
+      "name": "Specific Game Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<SG1>",
+          "description": "Starting a Match",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG1.html"
+        },
+        {
+          "rule": "<SG2>",
+          "description": "Horizontal expansion is limited",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG2.html"
+        },
+        {
+          "rule": "<SG3>",
+          "description": "Vertical expansion is limited",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG3.html"
+        },
+        {
+          "rule": "<SG4>",
+          "description": "Keep Scoring Objects in the field",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG4.html"
+        },
+        {
+          "rule": "<SG5>",
+          "description": "Each Robot gets one Ring as a preload",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG5.html"
+        },
+        {
+          "rule": "<SG6>",
+          "description": "Possession is limited to two Rings and one Mobile Goal",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG6.html"
+        },
+        {
+          "rule": "<SG7>",
+          "description": "Don't cross the Autonomous Line",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG7.html"
+        },
+        {
+          "rule": "<SG8>",
+          "description": "Engage with the Autonomous Line at your own risk",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG8.html"
+        },
+        {
+          "rule": "<SG9>",
+          "description": "Don't remove opponents from the Ladder",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG9.html"
+        },
+        {
+          "rule": "<SG10>",
+          "description": "Alliance Wall Stakes are protected",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG10.html"
+        },
+        {
+          "rule": "<SG11>",
+          "description": "Positive Corners are \"safe\" during the endgame.",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SG11.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC General Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUG1>",
+          "description": "Different expansion",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUG1.html"
+        },
+        {
+          "rule": "<VUG2>",
+          "description": "Different climbing",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUG2.html"
+        },
+        {
+          "rule": "<VUG3>",
+          "description": "Different autonomous",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUG3.html"
+        }
+      ]
+    },
+    {
+      "name": "General Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<G1>",
+          "description": "Treat everyone with respect",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G1.html"
+        },
+        {
+          "rule": "<G2>",
+          "description": "V5RC is a student-centered program",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G2.html"
+        },
+        {
+          "rule": "<G3>",
+          "description": "Use common sense",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G3.html"
+        },
+        {
+          "rule": "<G4>",
+          "description": "The Robot must represent the skill level of the Team",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G4.html"
+        },
+        {
+          "rule": "<G5>",
+          "description": "Robots begin the Match in the starting volume",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G5.html"
+        },
+        {
+          "rule": "<G6>",
+          "description": "Keep your Robots together",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G6.html"
+        },
+        {
+          "rule": "<G7>",
+          "description": "Don't clamp your Robot to the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G7.html"
+        },
+        {
+          "rule": "<G8>",
+          "description": "Only Drive Team Members, and only in the Alliance Station",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G8.html"
+        },
+        {
+          "rule": "<G9>",
+          "description": "Hands out of the field",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G9.html"
+        },
+        {
+          "rule": "<G10>",
+          "description": "Controllers must stay connected to the field",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G10.html"
+        },
+        {
+          "rule": "<G11>",
+          "description": "Autonomous means “no humans",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G11.html"
+        },
+        {
+          "rule": "<G12>",
+          "description": "All rules still apply in the Autonomous Period",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G12.html"
+        },
+        {
+          "rule": "<G13>",
+          "description": "Don't destroy other Robots",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G13.html"
+        },
+        {
+          "rule": "<G14>",
+          "description": "Offensive Robots get the “benefit of the doubt",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G14.html"
+        },
+        {
+          "rule": "<G15>",
+          "description": "You can't force an opponent into a penalty",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G15.html"
+        },
+        {
+          "rule": "<G16>",
+          "description": "No Holding for more than a 5-count",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G16.html"
+        },
+        {
+          "rule": "<G17>",
+          "description": "Use Scoring Objects to play the game",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/G17.html"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Be safe out there",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/S1.html"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Students must be accompanied by an Adult",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/S2.html"
+        },
+        {
+          "rule": "<S3>",
+          "description": "Stay inside the field",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/S3.html"
+        },
+        {
+          "rule": "<S4>",
+          "description": "Wear safety glasses",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/S4.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Robot Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUR1>",
+          "description": "Teams may use two (2) Robots in each Match",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR1.html"
+        },
+        {
+          "rule": "<VUR2>",
+          "description": "Teams may use any official VEX Robotics products, other than the exceptions listed in the tables below, to construct their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR2.html"
+        },
+        {
+          "rule": "<VUR3>",
+          "description": "Fabricated Parts may be made by applying the following manufacturing processes to legal Raw Stock:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR3.html"
+        },
+        {
+          "rule": "<VUR4>",
+          "description": "Fabricated Parts must be made from legal Raw Stock",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR4.html"
+        },
+        {
+          "rule": "<VUR5>",
+          "description": "The following material types are not considered Raw Stock, and are therefore not permitted:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR5.html"
+        },
+        {
+          "rule": "<VUR6>",
+          "description": "Fabricated Parts may not be made from Raw Stock which poses a safety or damage risk to the event, other Teams, or Field Elements",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR6.html"
+        },
+        {
+          "rule": "<VUR7>",
+          "description": "Fabricated Parts must be made by Team members",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR7.html"
+        },
+        {
+          "rule": "<VUR8>",
+          "description": "Teams may use commercially available springs on their Robots",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR8.html"
+        },
+        {
+          "rule": "<VUR9>",
+          "description": "Teams may use commercially available fastener hardware on their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR9.html"
+        },
+        {
+          "rule": "<VUR10>",
+          "description": "Each Robot must utilize exactly one (1) V5 Robot Brain and up to two (2) V5 Robot Radios connected to a V5 Controller",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR10.html"
+        },
+        {
+          "rule": "<VUR11>",
+          "description": "There is no restriction on the number of V5 Smart Motors (11W) [276-4840] and/or EXP Smart Motors (5",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR11.html"
+        },
+        {
+          "rule": "<VUR12>",
+          "description": "There is no restriction on sensors and other Additional Electronics that Robots may use for sensing and processing, except as follows:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR12.html"
+        },
+        {
+          "rule": "<VUR13>",
+          "description": "Teams may utilize an unlimited amount of the following commercially available pneumatic components: cylinders, actuators, valves, gauges, storage tanks, regulators, manifolds, tubing, and solenoids",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR13.html"
+        },
+        {
+          "rule": "<VUR14>",
+          "description": "Teams may use commercially available bearings on their Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUR14.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<R1>",
+          "description": "One Robot per Team",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R1.html"
+        },
+        {
+          "rule": "<R2>",
+          "description": "Robots must represent the Team's skill level",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R2.html"
+        },
+        {
+          "rule": "<R3>",
+          "description": "Robots must pass inspection",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R3.html"
+        },
+        {
+          "rule": "<R4>",
+          "description": "Robots must fit within an 18” x 18” x 18” volume",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R4.html"
+        },
+        {
+          "rule": "<R5>",
+          "description": "Robots may only expand horizontally in one direction",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R5.html"
+        },
+        {
+          "rule": "<R6>",
+          "description": "Robots must be safe",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R6.html"
+        },
+        {
+          "rule": "<R7>",
+          "description": "Robots are built from the VEX V5 system",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R7.html"
+        },
+        {
+          "rule": "<R8>",
+          "description": "Certain non-VEX components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R8.html"
+        },
+        {
+          "rule": "<R9>",
+          "description": "Decorations are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R9.html"
+        },
+        {
+          "rule": "<R10>",
+          "description": "Officially registered Team numbers must be displayed on Robot license plates",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R10.html"
+        },
+        {
+          "rule": "<R11>",
+          "description": "Let go of Scoring Objects after the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R11.html"
+        },
+        {
+          "rule": "<R12>",
+          "description": "Robots have one Brain",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R12.html"
+        },
+        {
+          "rule": "<R13>",
+          "description": "Motors are limited",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R13.html"
+        },
+        {
+          "rule": "<R14>",
+          "description": "Electrical power comes from VEX batteries only",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R14.html"
+        },
+        {
+          "rule": "<R15>",
+          "description": "No modifications to electronic or pneumatic components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R15.html"
+        },
+        {
+          "rule": "<R16>",
+          "description": "Most modifications to non-electrical components are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R16.html"
+        },
+        {
+          "rule": "<R17>",
+          "description": "Robots use VEXnet",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R17.html"
+        },
+        {
+          "rule": "<R18>",
+          "description": "Give the radio some space",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R18.html"
+        },
+        {
+          "rule": "<R19>",
+          "description": "A limited amount of custom plastic is allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R19.html"
+        },
+        {
+          "rule": "<R20>",
+          "description": "A limited amount of tape is allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R20.html"
+        },
+        {
+          "rule": "<R21>",
+          "description": "Certain non-VEX fasteners are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R21.html"
+        },
+        {
+          "rule": "<R22>",
+          "description": "New VEX parts are legal",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R22.html"
+        },
+        {
+          "rule": "<R23>",
+          "description": "Pneumatics are limited",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R23.html"
+        },
+        {
+          "rule": "<R24>",
+          "description": "One or two Controllers per Robot",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R24.html"
+        },
+        {
+          "rule": "<R25>",
+          "description": "Custom V5 Smart Cables are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R25.html"
+        },
+        {
+          "rule": "<R26>",
+          "description": "Keep the power button accessible",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R26.html"
+        },
+        {
+          "rule": "<R27>",
+          "description": "Use a “Competition Template” for programming",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R27.html"
+        },
+        {
+          "rule": "<R28>",
+          "description": "There is a difference between accidentally and willfully violating a Robot rule",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/R28.html"
+        }
+      ]
+    },
+    {
+      "name": "Scoring Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<SC1>",
+          "description": "All Scoring statuses are evaluated after the Match ends",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC1.html"
+        },
+        {
+          "rule": "<SC2>",
+          "description": "Scoring of the Autonomous Bonus is evaluated immediately after the Autonomous Period ends (i",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC2.html"
+        },
+        {
+          "rule": "<SC3>",
+          "description": "A Ring is considered Scored on a Stake if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC3.html"
+        },
+        {
+          "rule": "<SC4>",
+          "description": "A Ring is considered a Top Ring if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC4.html"
+        },
+        {
+          "rule": "<SC5>",
+          "description": "A Mobile Goal is considered Placed in a Corner if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC5.html"
+        },
+        {
+          "rule": "<SC6>",
+          "description": "A Mobile Goal that has been Placed will result in the following Corner modifiers to its Scored Rings:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC6.html"
+        },
+        {
+          "rule": "<SC7>",
+          "description": "A Robot is considered to have Climbed to a Level if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC7.html"
+        },
+        {
+          "rule": "<SC8>",
+          "description": "An Autonomous Win Point is awarded to any Alliance that ends the Autonomous Period with the following tasks completed, and that has not broken any rules during the Autonomous Period: At least three (3) Scored Rings A minimum of two (2) Stakes with at least(1) Ring Scored Neither Robot contacting / breaking the plane of the Starting Line One (1) Robot contacting the Ladder",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC8.html"
+        },
+        {
+          "rule": "<SC9>",
+          "description": "A High Stake bonus is available to an Alliance that ends the Match with a Ring Scored on the High Stake.",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/SC9.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Robot Skills Challenge Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VURS1>",
+          "description": "The VURC Robot Skills Challenge playing field layout differs from the layout for V5RC Robot Skills Matches, with the following modifications:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VURS1.html"
+        },
+        {
+          "rule": "<VURS2>",
+          "description": "Both Robots must start the Robot Skills Match in legal starting positions for the red Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VURS2.html"
+        },
+        {
+          "rule": "<VURS3>",
+          "description": "There are no preloads in VURC Robot Skills Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VURS3.html"
+        },
+        {
+          "rule": "<VURS4>",
+          "description": "Each blue Ring only has a point value if:",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VURS4.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Skills Challenge Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<RSC1>",
+          "description": "All rules from “The Game” section of the manual apply to the Robot Skills Challenge, unless otherwise specified in this section",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC1.html"
+        },
+        {
+          "rule": "<RSC2>",
+          "description": "Teams may play Robot Skills Matches on a first-come, first-served basis, or by a pre-scheduled method determined by the Event Partner",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC2.html"
+        },
+        {
+          "rule": "<RSC3>",
+          "description": "Robots must start the Robot Skills Match in a legal starting position for the red Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC3.html"
+        },
+        {
+          "rule": "<RSC4>",
+          "description": "Teams may only utilize the blue Rings as Top Rings on Stakes",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC4.html"
+        },
+        {
+          "rule": "<RSC5>",
+          "description": "Any red Ring Scored above a blue Ring on the same Stake will not have a point value",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC5.html"
+        },
+        {
+          "rule": "<RSC6>",
+          "description": "If any Ring is Scored on a Stake but does not have a point value based on rule <RSC4> or <RSC5>, no Ring on that Stake will earn points as a Top Ring",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC6.html"
+        },
+        {
+          "rule": "<RSC7>",
+          "description": "No Corner Modifiers",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC7.html"
+        },
+        {
+          "rule": "<RSC8>",
+          "description": "There is no requirement that Skills Challenge Fields have the same consistent modifications as the Head-to-Head Fields",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/RSC8.html"
+        }
+      ]
+    },
+    {
+      "name": "VURC Tournament Rules",
+      "programs": ["VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<VUT1>",
+          "description": "Instead of a 2-Team Alliance format, VEX U Matches will be played 1-Team vs",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT1.html"
+        },
+        {
+          "rule": "<VUT2>",
+          "description": "Qualification Matches will be conducted in the same manner as in a V5RC tournament, but in the revised 1v1 format described in <VUT1>",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT2.html"
+        },
+        {
+          "rule": "<VUT3>",
+          "description": "Elimination Matches will be conducted in the same manner as in a V5RC tournament, but without an Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT3.html"
+        },
+        {
+          "rule": "<VUT4>",
+          "description": "The Autonomous Period at the beginning of each Head-to-Head Match will be 30 seconds (0:30)",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT4.html"
+        },
+        {
+          "rule": "<VUT5>",
+          "description": "The Driver Controlled Period is shortened to 90 seconds (1:30) and immediately follows the Autonomous Period",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT5.html"
+        },
+        {
+          "rule": "<VUT6>",
+          "description": "Each Robot is allowed up to three (3) Drive Team Members in the Alliance Station during a Match, as modified from <G8>",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT6.html"
+        },
+        {
+          "rule": "<VUT7>",
+          "description": "VEX U Student eligibility",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/VUT7.html"
+        }
+      ]
+    },
+    {
+      "name": "Tournament Rules",
+      "programs": ["V5RC", "VURC", "VAIRC"],
+      "rules": [
+        {
+          "rule": "<T1>",
+          "description": "Head Referees have ultimate and final authority on all gameplay ruling decisions during the competition",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T1.html"
+        },
+        {
+          "rule": "<T2>",
+          "description": "Head Referees must be qualified",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T2.html"
+        },
+        {
+          "rule": "<T3>",
+          "description": "The Drive Team is permitted to immediately appeal a Head Referee's ruling",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T3.html"
+        },
+        {
+          "rule": "<T4> ",
+          "description": "The Event Partner has ultimate authority regarding all non-gameplay decisions during an event",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T4.html"
+        },
+        {
+          "rule": "<T5>",
+          "description": "A Team's Robot and/or Drive Team Member should attend every Match",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T5.html"
+        },
+        {
+          "rule": "<T6>",
+          "description": "Robots at the field must be ready to play",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T6.html"
+        },
+        {
+          "rule": "<T7>",
+          "description": "Match replays are allowed, but rare",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T7.html"
+        },
+        {
+          "rule": "<T8>",
+          "description": "Disqualifications",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T8.html"
+        },
+        {
+          "rule": "<T9>",
+          "description": "Each Elimination Alliance gets one Time Out",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T9.html"
+        },
+        {
+          "rule": "<T10>",
+          "description": "Be prepared for minor field variance",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T10.html"
+        },
+        {
+          "rule": "<T11>",
+          "description": "Fields may be repaired at the Event Partner's discretion",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T11.html"
+        },
+        {
+          "rule": "<T12>",
+          "description": "The red Alliance places last",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T12.html"
+        },
+        {
+          "rule": "<T13>",
+          "description": "Qualification Matches follow the Match schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T13.html"
+        },
+        {
+          "rule": "<T14>",
+          "description": "Each Team will have at least six Qualification Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T14.html"
+        },
+        {
+          "rule": "<T15>",
+          "description": "Qualification Matches contribute to a Team's ranking for Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T15.html"
+        },
+        {
+          "rule": "<T16>",
+          "description": "Qualification Match tiebreakers",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T16.html"
+        },
+        {
+          "rule": "<T17>",
+          "description": "Send a Student representative to Alliance Selection",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T17.html"
+        },
+        {
+          "rule": "<T18>",
+          "description": "Each Team may only be invited once to join one Alliance",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T18.html"
+        },
+        {
+          "rule": "<T19>",
+          "description": "Elimination Matches follow the Elimination Bracket",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T19.html"
+        },
+        {
+          "rule": "<T20>",
+          "description": "Elimination Matches are a blend of “Best of 1” and “Best of 3",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T20.html"
+        },
+        {
+          "rule": "<T21>",
+          "description": "Small tournaments may have fewer Alliances",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T21.html"
+        },
+        {
+          "rule": "<T22>",
+          "description": "Fields at an event must be consistent with each other",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T22.html"
+        },
+        {
+          "rule": "<T23>",
+          "description": "There are three types of field control that may be used: A VEXnet Field Controller controlled by Tournament Manager, which connects to a Controller's competition port via ethernet cable",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T23.html"
+        },
+        {
+          "rule": "<T24>",
+          "description": "There are two types of Field Perimeter that may be used: VEX Metal Competition Field Perimeter (SKU 278-1501) VEX Portable Competition Field Perimeter (SKU 276-8242) See Appendix A for more details",
+          "link": "https://www.robotevents.com/storage/game_manual/V5RC_2024-2025_High_Stakes/rules/T24.html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/rules/VIQRC/2023-2024.json
+++ b/public/rules/VIQRC/2023-2024.json
@@ -1,0 +1,385 @@
+{
+  "$schema": "https://referee.fyi/rules/schema.json",
+  "title": "Full Volume",
+  "season": "2023-2024",
+  "programs": ["VIQRC"],
+  "ruleGroups": [
+    {
+      "name": "Specific Game Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<SG1>",
+          "description": "Pre-match setup",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SG1.html"
+        },
+        {
+          "rule": "<SG2>",
+          "description": "Horizontal expansion is limited during a Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SG2.html"
+        },
+        {
+          "rule": "<SG3>",
+          "description": "Keep Blocks in the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SG3.html"
+        },
+        {
+          "rule": "<SG4>",
+          "description": "Blocks are randomly loaded in the Supply Zone",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SG4.html"
+        }
+      ]
+    },
+    {
+      "name": "General Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<G1>",
+          "description": "Treat everyone with respect",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G1.html"
+        },
+        {
+          "rule": "<G2>",
+          "description": "VIQRC is a student-centered program",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G2.html"
+        },
+        {
+          "rule": "<G3>",
+          "description": "Use common sense",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G3.html"
+        },
+        {
+          "rule": "<G4>",
+          "description": "The Robot must represent the skill level of the Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G4.html"
+        },
+        {
+          "rule": "<G5>",
+          "description": "Robots begin the Match in the starting size",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G5.html"
+        },
+        {
+          "rule": "<G6>",
+          "description": "Keep your Robot together",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G6.html"
+        },
+        {
+          "rule": "<G7>",
+          "description": "Don't damage the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G7.html"
+        },
+        {
+          "rule": "<G8>",
+          "description": "Drivers drive your Robot, and stay in the Driver Station",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G8.html"
+        },
+        {
+          "rule": "<G9>",
+          "description": "Hands out of the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G9.html"
+        },
+        {
+          "rule": "<G10>",
+          "description": "Handling the Robot mid-match is allowed under certain circumstances",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G10.html"
+        },
+        {
+          "rule": "<G11>",
+          "description": "A Team's two Drivers switch Controllers midway through the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/G11.html"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Stay safe, don't damage the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/S1.html"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Students must be accompanied by an Adult",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/S2.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<R1>",
+          "description": "One Robot per Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R1.html"
+        },
+        {
+          "rule": "<R2>",
+          "description": "Robots must represent the Team's skill level",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R2.html"
+        },
+        {
+          "rule": "<R3>",
+          "description": "Robots must pass inspection",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R3.html"
+        },
+        {
+          "rule": "<R4>",
+          "description": "Starting configuration",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R4.html"
+        },
+        {
+          "rule": "<R5>",
+          "description": "Prohibited items",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R5.html"
+        },
+        {
+          "rule": "<R6>",
+          "description": "VEX IQ product line",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R6.html"
+        },
+        {
+          "rule": "<R7>",
+          "description": "Non-VEX IQ components",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R7.html"
+        },
+        {
+          "rule": "<R8>",
+          "description": "Decorations are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R8.html"
+        },
+        {
+          "rule": "<R9>",
+          "description": "Officially registered Team numbers must be displayed on Robot License Plates",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R9.html"
+        },
+        {
+          "rule": "<R10>",
+          "description": "Let it go after the Match is over",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R10.html"
+        },
+        {
+          "rule": "<R11>",
+          "description": "Robot Brain",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R11.html"
+        },
+        {
+          "rule": "<R12>",
+          "description": "Motors",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R12.html"
+        },
+        {
+          "rule": "<R13>",
+          "description": "Batteries",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R13.html"
+        },
+        {
+          "rule": "<R14>",
+          "description": "Firmware",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R14.html"
+        },
+        {
+          "rule": "<R15>",
+          "description": "Modifications of parts",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R15.html"
+        },
+        {
+          "rule": "<R16>",
+          "description": "Pneumatics",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R16.html"
+        },
+        {
+          "rule": "<R17>",
+          "description": "There is a difference between accidentally and willfully violating a Robot rule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/R17.html"
+        }
+      ]
+    },
+    {
+      "name": "Scoring Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<SC1>",
+          "description": "All Scoring statuses are evaluated after the Match ends, once all Scored Blocks, Field Elements, and Robots on the Field come to rest",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC1.html"
+        },
+        {
+          "rule": "<SC2>",
+          "description": "All Scoring statuses are evaluated visually by a Head Referee, to the best of their ability within the context of a given Match/event",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC2.html"
+        },
+        {
+          "rule": "<SC3>",
+          "description": "A Block is considered Scored in a Goal if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC3.html"
+        },
+        {
+          "rule": "<SC4>",
+          "description": "A Goal is considered Uniform if it meets the following criteria:",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC4.html"
+        },
+        {
+          "rule": "<SC5>",
+          "description": "A Height Bonus is awarded for the highest Fill Level shared by all three Goals",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC5.html"
+        },
+        {
+          "rule": "<SC6>",
+          "description": "Goal Scoring Examples:",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC6.html"
+        },
+        {
+          "rule": "<SC7> ",
+          "description": "Referees will verify if a Robot is Fully or Partially Parked by sliding a right-angle tool (such as a VEX IQ beam/plate) along the outside edge of the red PVC pipe or the Field Perimeter",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/SC7.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Skills Challenge Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<RSC1>",
+          "description": "Standard rules apply in most cases",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC1.html"
+        },
+        {
+          "rule": "<RSC2>",
+          "description": "Skills Scoring and Ranking at events",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC2.html"
+        },
+        {
+          "rule": "<RSC3>",
+          "description": "Skills Rankings Globally",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC3.html"
+        },
+        {
+          "rule": "<RSC4>",
+          "description": "Skills Match Schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC4.html"
+        },
+        {
+          "rule": "<RSC5>",
+          "description": "Handling Robots during an Autonomous Coding Skills Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC5.html"
+        },
+        {
+          "rule": "<RSC6>",
+          "description": "Starting an Autonomous Coding Skills Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC6.html"
+        },
+        {
+          "rule": "<RSC7>",
+          "description": "Skills Stop Time",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/RSC7.html"
+        }
+      ]
+    },
+    {
+      "name": "Tournament Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<T1>",
+          "description": "The Head Referee has ultimate and final authority on all gameplay ruling decisions during the competition",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T1.html"
+        },
+        {
+          "rule": "<T2>",
+          "description": "Head Referees must be qualified",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T2.html"
+        },
+        {
+          "rule": "<T3>",
+          "description": "The Drivers are permitted to immediately appeal the Head Referee's ruling",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T3.html"
+        },
+        {
+          "rule": "<T4>",
+          "description": "The Event Partner has ultimate authority regarding all non-gameplay decisions during an event",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T4.html"
+        },
+        {
+          "rule": "<T5>",
+          "description": "Be at your match on time",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T5.html"
+        },
+        {
+          "rule": "<T6>",
+          "description": "Robots at the field must be ready to play",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T6.html"
+        },
+        {
+          "rule": "<T7>",
+          "description": "Match Replays are allowed, but rare",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T7.html"
+        },
+        {
+          "rule": "<T8>",
+          "description": "Disqualifications",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T8.html"
+        },
+        {
+          "rule": "<T9>",
+          "description": "Timeouts",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T9.html"
+        },
+        {
+          "rule": "<T10>",
+          "description": "Be prepared for minor field variance",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T10.html"
+        },
+        {
+          "rule": "<T11>",
+          "description": "Fields and Field Elements may be repaired at the Event Partner's discretion",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T11.html"
+        },
+        {
+          "rule": "<T12>",
+          "description": "Teamwork Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T12.html"
+        },
+        {
+          "rule": "<T13>",
+          "description": "Ending a Match early",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T13.html"
+        },
+        {
+          "rule": "<T14>",
+          "description": "Practice Matches may be played at some events, but are not required",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T14.html"
+        },
+        {
+          "rule": "<T15>",
+          "description": "Qualification Matches will occur according to the official match schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T15.html"
+        },
+        {
+          "rule": "<T16>",
+          "description": "Each Team will be scheduled Qualification Matches as follows",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T16.html"
+        },
+        {
+          "rule": "<T17>",
+          "description": "Teams are ranked by their average Qualification Match scores",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T17.html"
+        },
+        {
+          "rule": "<T18>",
+          "description": "Teams playing in Finals Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T18.html"
+        },
+        {
+          "rule": "<T19>",
+          "description": "Finals Match Schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2023-2024_Full_Volume/rules/T19.html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/rules/VIQRC/2024-2025.json
+++ b/public/rules/VIQRC/2024-2025.json
@@ -1,0 +1,415 @@
+{
+  "$schema": "https://referee.fyi/rules/schema.json",
+  "title": "Rapid Relay",
+  "season": "2024-2025",
+  "programs": ["VIQRC"],
+  "ruleGroups": [
+    {
+      "name": "Specific Game Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<SG1>",
+          "description": "Pre-match setup",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG1.html"
+        },
+        {
+          "rule": "<SG2>",
+          "description": "Robot expansion is limited",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG2.html"
+        },
+        {
+          "rule": "<SG3>",
+          "description": "Keep Balls in the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG3.html"
+        },
+        {
+          "rule": "<SG4>",
+          "description": "Using the Loading Station",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG4.html"
+        },
+        {
+          "rule": "<SG5>",
+          "description": "Loading during the Rapid Load Period",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG5.html"
+        },
+        {
+          "rule": "<SG6>",
+          "description": "Retrieving Balls from the Pickup Zone",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SG6.html"
+        }
+      ]
+    },
+    {
+      "name": "General Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<G1>",
+          "description": "Treat everyone with respect",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G1.html"
+        },
+        {
+          "rule": "<G2>",
+          "description": "VIQRC is a student-centered program",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G2.html"
+        },
+        {
+          "rule": "<G3>",
+          "description": "Use common sense",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G3.html"
+        },
+        {
+          "rule": "<G4>",
+          "description": "The Robot must represent the skill level of the Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G4.html"
+        },
+        {
+          "rule": "<G5>",
+          "description": "Robots begin the Match in the starting size",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G5.html"
+        },
+        {
+          "rule": "<G6>",
+          "description": "Keep your Robot together",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G6.html"
+        },
+        {
+          "rule": "<G7>",
+          "description": "Don't damage the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G7.html"
+        },
+        {
+          "rule": "<G8>",
+          "description": "Drivers drive your Robot, and stay in the Driver Station",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G8.html"
+        },
+        {
+          "rule": "<G9>",
+          "description": "Hands out of the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G9.html"
+        },
+        {
+          "rule": "<G10>",
+          "description": "Handling the Robot mid-match is allowed under certain circumstances",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G10.html"
+        },
+        {
+          "rule": "<G11>",
+          "description": "A Team's two Drivers switch Controllers midway through the Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/G11.html"
+        }
+      ]
+    },
+    {
+      "name": "Safety Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<S1>",
+          "description": "Stay safe, don't damage the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/S1.html"
+        },
+        {
+          "rule": "<S2>",
+          "description": "Students must be accompanied by an Adult",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/S2.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<R1>",
+          "description": "One Robot per Team",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R1.html"
+        },
+        {
+          "rule": "<R2>",
+          "description": "Robots must represent the Team's skill level",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R2.html"
+        },
+        {
+          "rule": "<R3>",
+          "description": "Robots must pass inspection",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R3.html"
+        },
+        {
+          "rule": "<R4>",
+          "description": "Starting configuration",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R4.html"
+        },
+        {
+          "rule": "<R5>",
+          "description": "Prohibited items",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R5.html"
+        },
+        {
+          "rule": "<R6>",
+          "description": "VEX IQ product line",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R6.html"
+        },
+        {
+          "rule": "<R7>",
+          "description": "Non-VEX IQ components",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R7.html"
+        },
+        {
+          "rule": "<R8>",
+          "description": "Decorations are allowed",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R8.html"
+        },
+        {
+          "rule": "<R9>",
+          "description": "Officially registered Team numbers must be displayed on Robot License Plates",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R9.html"
+        },
+        {
+          "rule": "<R10>",
+          "description": "Let it go after the Match is over",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R10.html"
+        },
+        {
+          "rule": "<R11>",
+          "description": "Robot Brain",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R11.html"
+        },
+        {
+          "rule": "<R12>",
+          "description": "Motors",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R12.html"
+        },
+        {
+          "rule": "<R13>",
+          "description": "Batteries",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R13.html"
+        },
+        {
+          "rule": "<R14>",
+          "description": "Firmware",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R14.html"
+        },
+        {
+          "rule": "<R15>",
+          "description": "Modifications of parts",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R15.html"
+        },
+        {
+          "rule": "<R16>",
+          "description": "Pneumatics",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R16.html"
+        },
+        {
+          "rule": "<R17>",
+          "description": "There is a difference between accidentally and willfully violating a Robot rule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/R17.html"
+        }
+      ]
+    },
+    {
+      "name": "Scoring Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<SC1>",
+          "description": "All Scoring statuses are evaluated after the Match ends, once all Balls, Field Elements, and Robots on the Field come to rest",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC1.html"
+        },
+        {
+          "rule": "<SC2>",
+          "description": "All Scoring statuses are evaluated visually by a Head Referee, to the best of their ability within the context of a given Match/event",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC2.html"
+        },
+        {
+          "rule": "<SC3>",
+          "description": "An Alliance Scores a Goal once a Ball is no longer in contact with a Robot and has fully passed through a Target (i",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC3.html"
+        },
+        {
+          "rule": "<SC4>",
+          "description": "A Switch is Cleared once it has been struck by a Ball and is no longer parallel with the front face of the Goal Wall",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC4.html"
+        },
+        {
+          "rule": "<SC5>",
+          "description": "An Alliance receives credit for a Pass once both Robots independently contact a Ball before it leaves the Field",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC5.html"
+        },
+        {
+          "rule": "<SC6>",
+          "description": "At the end of a Match, an Alliance cannot receive points for more Passes than Goals*",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC6.html"
+        },
+        {
+          "rule": "<SC7>",
+          "description": "Rapid Relay is designed to be scored in “real-time” as the Match is being played",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/SC7.html"
+        }
+      ]
+    },
+    {
+      "name": "Tournament Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<T1>",
+          "description": "The Head Referee has ultimate and final authority on all gameplay ruling decisions during the competition",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T1.html"
+        },
+        {
+          "rule": "<T2>",
+          "description": "Head Referees must be qualified",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T2.html"
+        },
+        {
+          "rule": "<T3>",
+          "description": "The Drive Team Members are permitted to immediately appeal the Head Referee's ruling",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T3.html"
+        },
+        {
+          "rule": "<T4>",
+          "description": "The Event Partner has ultimate authority regarding all non-gameplay decisions during an event",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T4.html"
+        },
+        {
+          "rule": "<T5>",
+          "description": "Be at your match on time",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T5.html"
+        },
+        {
+          "rule": "<T6>",
+          "description": "Robots at the field must be ready to play",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T6.html"
+        },
+        {
+          "rule": "<T7>",
+          "description": "Match Replays are allowed, but rare",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T7.html"
+        },
+        {
+          "rule": "<T8>",
+          "description": "Disqualifications",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T8.html"
+        },
+        {
+          "rule": "<T9>",
+          "description": "Timeouts",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T9.html"
+        },
+        {
+          "rule": "<T10>",
+          "description": "Be prepared for minor field variance",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T10.html"
+        },
+        {
+          "rule": "<T11>",
+          "description": "Fields and Field Elements may be repaired at the Event Partner's discretion",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T11.html"
+        },
+        {
+          "rule": "<T12>",
+          "description": "Teamwork Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T12.html"
+        },
+        {
+          "rule": "<T13>",
+          "description": "Ending a Match early",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T13.html"
+        },
+        {
+          "rule": "<T14>",
+          "description": "Practice Matches may be played at some events, but are not required",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T14.html"
+        },
+        {
+          "rule": "<T15>",
+          "description": "Qualification Matches will occur according to the official match schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T15.html"
+        },
+        {
+          "rule": "<T16>",
+          "description": "Each Team will be scheduled Qualification Matches as follows",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T16.html"
+        },
+        {
+          "rule": "<T17>",
+          "description": "Teams are ranked by their average Qualification Match scores",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T17.html"
+        },
+        {
+          "rule": "<T18>",
+          "description": "Teams playing in Finals Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T18.html"
+        },
+        {
+          "rule": "<T19>",
+          "description": "Finals Match Schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/T19.html"
+        }
+      ]
+    },
+    {
+      "name": "Robot Skills Challenge Rules",
+      "programs": ["VIQRC"],
+      "rules": [
+        {
+          "rule": "<RSC1>",
+          "description": "Standard rules apply in most cases",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC1.html"
+        },
+        {
+          "rule": "<RSC2>",
+          "description": "Scoring Robot Skills Matches",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC2.html"
+        },
+        {
+          "rule": "<RSC3>",
+          "description": "Robot Skills Field setup",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC3.html"
+        },
+        {
+          "rule": "<RSC4>",
+          "description": "Loader differences",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC4.html"
+        },
+        {
+          "rule": "<RSC5>",
+          "description": "Skills Ranking at events",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC5.html"
+        },
+        {
+          "rule": "<RSC6>",
+          "description": "Skills Rankings Globally",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC6.html"
+        },
+        {
+          "rule": "<RSC7>",
+          "description": "Skills Match Schedule",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC7.html"
+        },
+        {
+          "rule": "<RSC8>",
+          "description": "Handling Robots during an Autonomous Coding Skills Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC8.html"
+        },
+        {
+          "rule": "<RSC9>",
+          "description": "Starting an Autonomous Coding Skills Match",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC9.html"
+        },
+        {
+          "rule": "<RSC10>",
+          "description": "Skills Stop Time",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC10.html"
+        },
+        {
+          "rule": "<RSC11>",
+          "description": "Robot Skills at League Events",
+          "link": "https://www.robotevents.com/storage/game_manual/VIQRC_2024-2025_Rapid_Relay/rules/RSC11.html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/rules/schema.json
+++ b/public/rules/schema.json
@@ -20,6 +20,13 @@
         "$ref": "#/$defs/program"
       },
       "description": "The programs that the game is for."
+    },
+    "ruleGroups": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ruleGroup"
+      },
+      "description": "The rule groups in the game."
     }
   },
   "$defs": {

--- a/public/rules/schema.json
+++ b/public/rules/schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://referee.fyi/rules/schema.json",
+  "title": "Referee FYI Game Schema",
+  "description": "Describes the shape of Referee FYI game descriptions.",
+  "type": "object",
+  "required": ["title", "season", "programs", "ruleGroups"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The game name."
+    },
+    "season": {
+      "type": "string",
+      "description": "The year (ex. 2024-2025) that the game applies to."
+    },
+    "programs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/program"
+      },
+      "description": "The programs that the game is for."
+    }
+  },
+  "$defs": {
+    "program": {
+      "enum": ["V5RC", "VURC", "VAIRC", "VIQRC", "ADC"],
+      "description": "The program abbreviation."
+    },
+    "ruleGroup": {
+      "required": ["title", "programs", "rules"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The rule group name."
+        },
+        "programs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/program"
+          },
+          "description": "The programs that the rule group is for."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/rule"
+          },
+          "description": "The rules in the group."
+        }
+      }
+    },
+    "rule": {
+      "required": ["name", "description", "link"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The rule name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Single-sentence quick-description of rule."
+        },
+        "link": {
+          "type": "string",
+          "format": "uri",
+          "description": "Game manual link to the rule."
+        }
+      }
+    }
+  }
+}

--- a/public/rules/schema.json
+++ b/public/rules/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft-07/schema#",
   "$id": "https://referee.fyi/rules/schema.json",
   "title": "Referee FYI Game Schema",
   "description": "Describes the shape of Referee FYI game descriptions.",

--- a/src/components/dialogs/edit.tsx
+++ b/src/components/dialogs/edit.tsx
@@ -61,7 +61,7 @@ export const EditIncidentDialog: React.FC<EditIncidentDialogProps> = ({
     return Object.entries(divisions);
   }, [teamMatches]);
 
-  const game = useRulesForEvent(eventData);
+  const { data: game } = useRulesForEvent(eventData);
 
   const [dirty, setDirty] = useState<Record<LWWKeys<Incident>, boolean>>({
     match: false,

--- a/src/pages/events/devtools.tsx
+++ b/src/pages/events/devtools.tsx
@@ -70,7 +70,7 @@ export const EventDevTools: React.FC = () => {
   );
 
   const { data: season } = useCurrentSeason(event?.program.id as ProgramCode);
-  const game = useRulesForSeason(season);
+  const { data: game } = useRulesForSeason(season);
   const rules = game?.ruleGroups.flatMap((group) => group.rules);
 
   const { mutate: generateIncidents, isPending: isGeneratePending } =

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -205,6 +205,7 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
       if (e.target.value === "-1") {
         setMatch(undefined);
         setTeam(undefined);
+        setIncidentField("skills", undefined);
       }
 
       if (!newMatch) return;

--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -43,7 +43,7 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
   const { data: event, isLoading: isLoadingEvent } = useCurrentEvent();
   const division = useCurrentDivision();
 
-  const rules = useRulesForEvent(event);
+  const { data: rules } = useRulesForEvent(event);
   const { data: recentRules } = useRecentRules(
     event?.program.id ?? programs.V5RC,
     4

--- a/src/pages/events/summary.tsx
+++ b/src/pages/events/summary.tsx
@@ -47,7 +47,7 @@ const FilterDialog: React.FC<FilterDialogProps> = ({
 }) => {
   const { data: event } = useCurrentEvent();
   const divisions = useMemo(() => event?.divisions ?? [], [event]);
-  const game = useRulesForEvent(event);
+  const { data: game } = useRulesForEvent(event);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
   const setFiltersField = useCallback(
     <T extends keyof Filters>(key: T, value: Filters[T]) => {

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -234,12 +234,14 @@ const Rules: React.FC = () => {
     programs.VIQRC,
     programs.VURC,
     programs.VAIRC,
+    programs.ADC,
   ];
   const selectableProgramAbbr: Partial<Record<ProgramCode, ProgramAbbr>> = {
     [programs.V5RC]: "V5RC",
     [programs.VIQRC]: "VIQRC",
     [programs.VURC]: "VURC",
     [programs.VAIRC]: "VAIRC",
+    [programs.ADC]: "ADC",
   };
 
   const [program, setProgram] = useState<ProgramCode>(programs.V5RC);

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -246,7 +246,7 @@ const Rules: React.FC = () => {
 
   const { data: currentSeasonForProgram } = useCurrentSeason(program);
   const { data: season } = useSeason(event?.season.id);
-  const rules = useRulesForSeason(season ?? currentSeasonForProgram);
+  const { data: rules } = useRulesForSeason(season ?? currentSeasonForProgram);
 
   const [rule, setRule] = useState<Rule | null>(null);
 

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -35,7 +35,7 @@ import { getShareProfile } from "~utils/data/share";
 
 function isValidSKU(sku: string) {
   return !!sku.match(
-    /RE-(VRC|V5RC|VEXU|VURC|VIQRC|VIQC|VAIRC)-[0-9]{2}-[0-9]{4}/g
+    /RE-(VRC|V5RC|VEXU|VURC|VIQRC|VIQC|VAIRC|ADC)-[0-9]{2}-[0-9]{4}/g
   );
 }
 

--- a/src/utils/data/rules.ts
+++ b/src/utils/data/rules.ts
@@ -1,0 +1,42 @@
+import { programs, seasons } from "robotevents";
+import { Game } from "~utils/hooks/rules";
+
+import HighStakes from "/rules/V5RC/2024-2025.json?url";
+import RapidRelay from "/rules/VIQRC/2024-2025.json?url";
+import MissionGravity from "/rules/ADC/2024-2025.json?url";
+
+import OverUnder from "/rules/V5RC/2023-2024.json?url";
+import FullVolume from "/rules/VIQRC/2023-2024.json?url";
+
+// 2024-2025
+export const HighStakesRules: () => Promise<Game> = async () =>
+  fetch(HighStakes).then((res) => res.json());
+
+export const RapidRelayRules: () => Promise<Game> = async () =>
+  fetch(RapidRelay).then((res) => res.json());
+
+export const MissionGravityRules: () => Promise<Game> = async () =>
+  fetch(MissionGravity).then((res) => res.json());
+
+// 2023-2024
+export const OverUnderRules: () => Promise<Game> = async () =>
+  fetch(OverUnder).then((res) => res.json());
+
+export const FullVolumeRules: () => Promise<Game> = async () =>
+  fetch(FullVolume).then((res) => res.json());
+
+// Supported games
+export const GAME_FETCHERS: Record<number, () => Promise<Game>> = {
+  // 2024-2025
+  [seasons[programs.V5RC]["2024-2025"]]: HighStakesRules,
+  [seasons[programs.VURC]["2024-2025"]]: HighStakesRules,
+  [seasons[programs.VAIRC]["2024-2025"]]: HighStakesRules,
+  [seasons[programs.VIQRC]["2024-2025"]]: RapidRelayRules,
+  [seasons[programs.ADC]["2024-2025"]]: MissionGravityRules,
+
+  // 2023-2024
+  [seasons[programs.V5RC]["2023-2024"]]: OverUnderRules,
+  [seasons[programs.VURC]["2023-2024"]]: OverUnderRules,
+  [seasons[programs.VAIRC]["2023-2024"]]: OverUnderRules,
+  [seasons[programs.VIQRC]["2023-2024"]]: FullVolumeRules,
+};

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -337,7 +337,7 @@ export function useEventTeam(
 }
 
 export const currentSeasons = (
-  [programs.V5RC, programs.VIQRC, programs.VURC] as const
+  [programs.V5RC, programs.VIQRC, programs.VURC, programs.ADC] as const
 ).map((program) => client.seasons[program][CURRENT_YEAR]) as number[];
 
 export function useEventsToday(

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -217,6 +217,8 @@ export function useDivisionTeams(
   });
 }
 
+const roundUnknown = 0;
+
 export function logicalMatchComparison(a: MatchData, b: MatchData) {
   const roundOrder = [
     rounds.Practice,
@@ -227,6 +229,7 @@ export function logicalMatchComparison(a: MatchData, b: MatchData) {
     rounds.Semifinals,
     rounds.Finals,
     rounds.TopN,
+    roundUnknown,
   ] as number[];
 
   if (a.round !== b.round) {


### PR DESCRIPTION
Closes #145 

Adds support for this year's ADC 2024-2025 game Mission: Gravity. In addition, this PR restructures some of the rule import code to split games into individual files and defines a JSON Schema for games for better Intellisense.

To Review:
- Order of Rules in the Picker
- Regressions in other functionality, especially related to rules