### PR TITLE
Reset skills field when the user selects a match

### DIFF
--- a/src/pages/events/dialogs/new.tsx
+++ b/src/pages/events/dialogs/new.tsx
@@ -212,6 +212,7 @@ export const EventNewIncidentDialog: React.FC<EventNewIncidentDialogProps> = ({
       if (!newMatch) return;
 
       setIncidentField("match", newMatch);
+      setIncidentField("skills", undefined);
       setMatch(newMatch.id);
     },
     [matches, allTeamMatches, division]


### PR DESCRIPTION
Fixes #160 

Fixes an issue in the new incident dialog where the skills details input stays around when you select a match after selecting skills.

**Testing Instructions**
1. Open the new incident dialog from the main homepage (i.e., don't prefill team or match)
2. Select `Skills` in the Match Select. You should see the skills type and match number quick selects appear below
3. Select a match. Confirm that the skills type and match number quick selects don't appear
4. Try other combinations to confirm things work as expected.