### PR TITLE
111 add team search functionality

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -3,6 +3,7 @@ import { Game, Rule } from "~utils/hooks/rules";
 import React, {
   Dispatch,
   forwardRef,
+  ReactNode,
   SetStateAction,
   useCallback,
   useId,
@@ -376,5 +377,28 @@ export const RulesMultiSelect: React.FC<RulesMultiSelectProps> = ({
         ))}
       </ul>
     </>
+  );
+};
+
+export type LabelSymbolProps = React.HTMLProps<HTMLLabelElement> & {
+  icon: ReactNode;
+};
+
+export const IconLabel: React.FC<LabelSymbolProps> = ({
+  icon,
+  children,
+  ...props
+}) => {
+  return (
+    <label
+      {...props}
+      className={twMerge(
+        "flex items-center gap-4 bg-zinc-700 pl-2 rounded-md",
+        props.className
+      )}
+    >
+      {icon}
+      {children}
+    </label>
   );
 };

--- a/src/pages/events/division.tsx
+++ b/src/pages/events/division.tsx
@@ -24,7 +24,7 @@ export const EventDivisionPickerPage: React.FC = () => {
         {event.divisions
           ?.sort((a, b) => a.order! - b.order!)
           .map((division) => (
-            <li key={division.id} className="mb-4">
+            <li key={division.id}>
               <LinkButton
                 className={"w-full"}
                 to={`/${event.sku}/${division.id}`}
@@ -33,7 +33,7 @@ export const EventDivisionPickerPage: React.FC = () => {
               </LinkButton>
             </li>
           ))}
-        <li className="mt-2">
+        <li>
           <LinkButton className={"w-full"} to={`/${event.sku}/skills`}>
             Skills
           </LinkButton>

--- a/src/pages/events/division.tsx
+++ b/src/pages/events/division.tsx
@@ -20,18 +20,23 @@ export const EventDivisionPickerPage: React.FC = () => {
 
   return (
     <section className="mt-4 flex flex-col gap-4">
-      <ol className="contents">
+      <ol className="overflow-auto max-h-screen">
         {event.divisions
           ?.sort((a, b) => a.order! - b.order!)
           .map((division) => (
-            <li className="contents">
-              <LinkButton to={`/${event.sku}/${division.id}`} key={division.id}>
+            <li key={division.id} className="mb-4">
+              <LinkButton
+                className={"w-full"}
+                to={`/${event.sku}/${division.id}`}
+              >
                 {division.name}
               </LinkButton>
             </li>
           ))}
-        <li className="contents">
-          <LinkButton to={`/${event.sku}/skills`}>Skills</LinkButton>
+        <li className="mt-2">
+          <LinkButton className={"w-full"} to={`/${event.sku}/skills`}>
+            Skills
+          </LinkButton>
         </li>
       </ol>
     </section>

--- a/src/pages/events/division.tsx
+++ b/src/pages/events/division.tsx
@@ -19,8 +19,8 @@ export const EventDivisionPickerPage: React.FC = () => {
   }
 
   return (
-    <section className="mt-4 flex flex-col gap-4">
-      <ol className="overflow-auto max-h-screen">
+    <section className="mt-4 flex flex-col gap-4 overflow-auto max-h-screen">
+      <ol className="contents">
         {event.divisions
           ?.sort((a, b) => a.order! - b.order!)
           .map((division) => (

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -8,6 +8,7 @@ import { ExclamationTriangleIcon, FlagIcon } from "@heroicons/react/20/solid";
 import { Link } from "react-router-dom";
 import { VirtualizedList } from "~components/VirtualizedList";
 import { Input } from "~components/Input";
+import { filterTeams } from "~utils/filterteams";
 
 export type EventTagProps = {
   event: EventData;
@@ -55,15 +56,8 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
     return grouped;
   }, [incidents]);
 
-  const filteredTeams = useMemo(() => {
-    if (!filter) return teams;
-
-    return teams.filter(
-      (team) =>
-        team.number.startsWith(filter) ||
-        team.team_name?.toUpperCase().includes(filter)
-    );
-  }, [filter, teams]);
+  const filteredTeams =
+    teams && useMemo(() => filterTeams(teams, filter), [filter, teams]);
 
   return (
     <section className="contents">

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -7,6 +7,7 @@ import { useCurrentDivision } from "~utils/hooks/state";
 import { ExclamationTriangleIcon, FlagIcon } from "@heroicons/react/20/solid";
 import { Link } from "react-router-dom";
 import { VirtualizedList } from "~components/VirtualizedList";
+import { Input } from "~components/Input";
 
 export type EventTagProps = {
   event: EventData;
@@ -67,13 +68,30 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
   return (
     <section className="contents">
       <Spinner show={isLoading || isPaused} />
-      <input
-        type="text"
-        placeholder="Team Name or Number"
-        id="searchBar"
-        className="rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2 hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-500 max-w-full w-full"
-        onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
-      ></input>
+      <div className="flex items-center gap-4">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+          />
+        </svg>
+
+        <Input
+          type="text"
+          placeholder="Team Name or Number"
+          id="searchBar"
+          className="z-10 w-full"
+          onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
+        ></Input>
+      </div>
       <VirtualizedList
         data={filteredTeams}
         options={{ estimateSize: () => 64 }}

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -24,7 +24,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
   const { data: incidents } = useEventIncidents(event.sku);
   const [filter, setFilter] = useState("");
 
-  const teams = divisionTeams?.teams ?? [];
+  const teams = useMemo(() => divisionTeams?.teams ?? [], [divisionTeams]);
 
   const majorIncidents = useMemo(() => {
     if (!incidents) return new Map<string, number>();
@@ -56,8 +56,10 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
     return grouped;
   }, [incidents]);
 
-  const filteredTeams =
-    teams && useMemo(() => filterTeams(teams, filter), [filter, teams]);
+  const filteredTeams = useMemo(
+    () => (teams ? filterTeams(teams, filter) : []),
+    [filter, teams]
+  );
 
   return (
     <section className="contents">

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -7,7 +7,7 @@ import { useCurrentDivision } from "~utils/hooks/state";
 import { ExclamationTriangleIcon, FlagIcon } from "@heroicons/react/20/solid";
 import { Link } from "react-router-dom";
 import { VirtualizedList } from "~components/VirtualizedList";
-import { Input } from "~components/Input";
+import { IconLabel, Input } from "~components/Input";
 import { filterTeams } from "~utils/filterteams";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
@@ -64,17 +64,15 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
 
   return (
     <section className="contents">
-      <Spinner show={isLoading || isPaused} />
-      <div className="flex items-center gap-4">
-        <MagnifyingGlassIcon height={24} />
+      <IconLabel icon={<MagnifyingGlassIcon height={24} />}>
         <Input
-          type="text"
-          placeholder="Team Name or Number"
-          id="searchBar"
-          className="z-10 w-full"
+          placeholder="Search teams..."
+          className="flex-1"
+          value={filter}
           onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
-        ></Input>
-      </div>
+        />
+      </IconLabel>
+      <Spinner show={isLoading || isPaused} />
       <VirtualizedList
         data={filteredTeams}
         options={{ estimateSize: () => 64 }}

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { EventData } from "robotevents";
 import { Spinner } from "~components/Spinner";
 import { useEventIncidents } from "~utils/hooks/incident";
@@ -20,6 +20,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
     isPaused,
   } = useDivisionTeams(event, division);
   const { data: incidents } = useEventIncidents(event.sku);
+  const [filter, setFilter] = useState("");
 
   const teams = divisionTeams?.teams ?? [];
 
@@ -53,11 +54,28 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
     return grouped;
   }, [incidents]);
 
+  const filteredTeams = useMemo(() => {
+    if (!filter) return teams;
+
+    return teams.filter(
+      (team) =>
+        team.number.startsWith(filter) ||
+        team.team_name?.toUpperCase().includes(filter)
+    );
+  }, [filter, teams]);
+
   return (
     <section className="contents">
       <Spinner show={isLoading || isPaused} />
+      <input
+        type="text"
+        placeholder="Team Name or Number"
+        id="searchBar"
+        className="rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2 hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-500 max-w-full w-full"
+        onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
+      ></input>
       <VirtualizedList
-        data={teams}
+        data={filteredTeams}
         options={{ estimateSize: () => 64 }}
         className="flex-1"
         parts={{ list: { className: "mb-12" } }}
@@ -78,7 +96,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
                 {team.team_name}
               </p>
             </div>
-            <p className="h-full w-32 px-2 flex items-center">
+            <div className="absolute right-0 bg-zinc-800 h-full w-32 px-2 flex items-center">
               <span className="text-red-400 mr-4" aria-label={``}>
                 <FlagIcon height={24} className="inline" />
                 <span className="font-mono ml-2">
@@ -91,7 +109,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
                   {minorIncidents.get(team.number) ?? 0}
                 </span>
               </span>
-            </p>
+            </div>
           </Link>
         )}
       </VirtualizedList>

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -9,6 +9,7 @@ import { Link } from "react-router-dom";
 import { VirtualizedList } from "~components/VirtualizedList";
 import { Input } from "~components/Input";
 import { filterTeams } from "~utils/filterteams";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
 export type EventTagProps = {
   event: EventData;
@@ -65,21 +66,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
     <section className="contents">
       <Spinner show={isLoading || isPaused} />
       <div className="flex items-center gap-4">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
-          className="size-6"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-          />
-        </svg>
-
+        <MagnifyingGlassIcon height={24} />
         <Input
           type="text"
           placeholder="Team Name or Number"

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -100,7 +100,7 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
                     {team.team_name}
                   </p>
                 </div>
-                <p className="h-full pl-2 flex items-center">
+                <div className="absolute right-0 bg-zinc-800 h-full pl-2 flex items-center">
                   <span className="mr-4">
                     <PlayIcon height={20} className="inline" />
                     <span className="font-mono ml-2">
@@ -113,7 +113,7 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
                       {programming?.attempts ?? 0}
                     </span>
                   </span>
-                </p>
+                </div>
               </Link>
             );
           }}

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -11,6 +11,7 @@ import { EventData } from "robotevents";
 import { useEventSkills, useEventTeams } from "~utils/hooks/robotevents";
 import { Link } from "react-router-dom";
 import { Skill } from "robotevents";
+import { Input } from "~components/Input";
 
 import { UserGroupIcon as TeamsIconOutline } from "@heroicons/react/24/outline";
 import { UserGroupIcon as TeamsIconSolid } from "@heroicons/react/24/solid";
@@ -63,13 +64,29 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
     <>
       <section className="contents">
         <Spinner show={isLoading} />
-        <input
-          type="text"
-          placeholder="Team Name or Number"
-          id="searchBar"
-          className="rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2 hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-500 max-w-full w-full"
-          onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
-        ></input>
+        <div className="flex items-center gap-4">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="size-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+            />
+          </svg>
+          <Input
+            type="text"
+            placeholder="Team Name or Number"
+            id="searchBar"
+            className="z-10 w-full"
+            onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
+          ></Input>
+        </div>
         <VirtualizedList
           className="flex-1"
           data={filteredTeams}

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -11,9 +11,12 @@ import { EventData } from "robotevents";
 import { useEventSkills, useEventTeams } from "~utils/hooks/robotevents";
 import { Link } from "react-router-dom";
 import { Skill } from "robotevents";
-import { Input } from "~components/Input";
+import { IconLabel, Input } from "~components/Input";
 
-import { UserGroupIcon as TeamsIconOutline } from "@heroicons/react/24/outline";
+import {
+  MagnifyingGlassIcon,
+  UserGroupIcon as TeamsIconOutline,
+} from "@heroicons/react/24/outline";
 import { UserGroupIcon as TeamsIconSolid } from "@heroicons/react/24/solid";
 
 import { Cog8ToothIcon as ManageIconOutline } from "@heroicons/react/24/outline";
@@ -59,30 +62,15 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
   return (
     <>
       <section className="contents">
-        <Spinner show={isLoading} />
-        <div className="flex items-center gap-4">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="size-6"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-            />
-          </svg>
+        <IconLabel icon={<MagnifyingGlassIcon height={24} />}>
           <Input
-            type="text"
-            placeholder="Team Name or Number"
-            id="searchBar"
-            className="z-10 w-full"
+            placeholder="Search teams..."
+            className="flex-1"
+            value={filter}
             onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
-          ></Input>
-        </div>
+          />
+        </IconLabel>
+        <Spinner show={isLoading} />
         <VirtualizedList
           className="flex-1"
           data={filteredTeams}

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -19,6 +19,7 @@ import { UserGroupIcon as TeamsIconSolid } from "@heroicons/react/24/solid";
 import { Cog8ToothIcon as ManageIconOutline } from "@heroicons/react/24/outline";
 import { Cog8ToothIcon as ManageIconSolid } from "@heroicons/react/24/solid";
 import { VirtualizedList } from "~components/VirtualizedList";
+import { filterTeams } from "~utils/filterteams";
 
 type TeamSkillsTabProps = {
   event: EventData;
@@ -50,15 +51,8 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
 
   const isLoading = isLoadingTeams || isLoadingSkills;
 
-  const filteredTeams = useMemo(() => {
-    if (!filter) return teams;
-
-    return teams?.filter(
-      (team) =>
-        team.number.startsWith(filter) ||
-        team.team_name?.toUpperCase().includes(filter)
-    );
-  }, [filter, teams]);
+  const filteredTeams =
+    teams && useMemo(() => filterTeams(teams, filter), [filter, teams]);
 
   return (
     <>

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -51,8 +51,10 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
 
   const isLoading = isLoadingTeams || isLoadingSkills;
 
-  const filteredTeams =
-    teams && useMemo(() => filterTeams(teams, filter), [filter, teams]);
+  const filteredTeams = useMemo(
+    () => (teams ? filterTeams(teams, filter) : []),
+    [filter, teams]
+  );
 
   return (
     <>

--- a/src/pages/events/skills.tsx
+++ b/src/pages/events/skills.tsx
@@ -26,6 +26,7 @@ type TeamSkillsTabProps = {
 const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
   const { data: teams, isLoading: isLoadingTeams } = useEventTeams(event);
   const { data: skills, isLoading: isLoadingSkills } = useEventSkills(event);
+  const [filter, setFilter] = useState("");
 
   const skillsByTeam = useMemo(() => {
     if (!skills) {
@@ -48,13 +49,30 @@ const TeamSkillsTab: React.FC<TeamSkillsTabProps> = ({ event }) => {
 
   const isLoading = isLoadingTeams || isLoadingSkills;
 
+  const filteredTeams = useMemo(() => {
+    if (!filter) return teams;
+
+    return teams?.filter(
+      (team) =>
+        team.number.startsWith(filter) ||
+        team.team_name?.toUpperCase().includes(filter)
+    );
+  }, [filter, teams]);
+
   return (
     <>
       <section className="contents">
         <Spinner show={isLoading} />
+        <input
+          type="text"
+          placeholder="Team Name or Number"
+          id="searchBar"
+          className="rounded-md bg-zinc-700 text-zinc-100 text-left px-3 py-2 hover:bg-zinc-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-zinc-500 max-w-full w-full"
+          onChange={(e) => setFilter(e.currentTarget.value.toUpperCase())}
+        ></input>
         <VirtualizedList
           className="flex-1"
-          data={teams}
+          data={filteredTeams}
           options={{ estimateSize: () => 64 }}
           parts={{ list: { className: "mb-12" } }}
         >

--- a/src/utils/filterteams.ts
+++ b/src/utils/filterteams.ts
@@ -1,0 +1,14 @@
+import { TeamData } from "robotevents";
+
+export const filterTeams = (
+  teams: TeamData[],
+  filter: string | null
+): TeamData[] => {
+  if (!filter) return teams;
+
+  return teams?.filter(
+    (team) =>
+      team.number.startsWith(filter) ||
+      team.team_name?.toUpperCase().includes(filter)
+  );
+};


### PR DESCRIPTION
Easier than splitting up `<SG6>` (I hope). The user can search by either:

 - Typing the start of the team number
This is designed to stop team `5123A` from showing up when typing `123`, as you are much more likely to be searching for `1234B`
 - Typing any part of the team name

While testing adding this to skills at Worlds, I noticed that the 'Divison Select' menu was not scrollable. So included a fix for that with this as well.

Tested with 860 teams at V5RC HS worlds last year and it was very responsive.