### PR TITLE
Fix edit button clipping with no incident notes

### DIFF
--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -86,7 +86,7 @@ export const Incident: React.FC<IncidentProps> = ({
           props.className
         )}
       >
-        <div className="flex-1 overflow-clip">
+        <div className="flex-auto overflow-hidden">
           <div className="text-sm whitespace-nowrap">
             <div className="flex items-center gap-x-1">
               <IncidentHighlights incident={incident} />
@@ -103,7 +103,7 @@ export const Incident: React.FC<IncidentProps> = ({
           <Button
             className={twMerge(
               IncidentOutcomeClasses[incident.outcome],
-              "w-min text-back/75 active:bg-black/50 py-4 px-4 my-0.5 absolute right-0 top-0 bottom-0"
+              "w-min text-back/75 active:bg-black/50 flex-none basis-auto"
             )}
             mode="transparent"
             onClick={() => setEditIncidentOpen(true)}

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -152,7 +152,7 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
         <>
           {incidents.map((incident) => (
             <Incident
-              className="h-14 overflow-hidden"
+              className="max-h-20 overflow-hidden"
               incident={incident}
               key={incident.id}
             />

--- a/src/pages/events/dialogs/match.tsx
+++ b/src/pages/events/dialogs/match.tsx
@@ -151,7 +151,11 @@ const TeamSummary: React.FC<TeamSummaryProps> = ({
       {open ? (
         <>
           {incidents.map((incident) => (
-            <Incident incident={incident} key={incident.id} />
+            <Incident
+              className="h-14 overflow-hidden"
+              incident={incident}
+              key={incident.id}
+            />
           ))}
           {incidents.length > 0 ? (
             <>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ea1f874b-6b14-478b-bcef-c15eaf3c462c)

Edit: Fixed it so that we aren't using position absolute anymore (which was causing the problem)

Now the edit button flexes properly, and the match dialog will shrink properly and not expand past 2 lines