### PR TITLE
Demo Fixes + Minor QOL Enhancements

### DIFF
--- a/lib/share/scratchpad.ts
+++ b/lib/share/scratchpad.ts
@@ -30,6 +30,7 @@ export type HighStakesMatchScratchpadProperties = {
   game: "High Stakes";
   awp: Record<Color, boolean>;
   auto: Color | "tie" | "none";
+  timeout_used: Record<Color, boolean>;
 };
 
 export type BaseHighStakesMatchScratchpad = BaseMatchScratchpad &

--- a/src/components/EditHistory.tsx
+++ b/src/components/EditHistory.tsx
@@ -9,8 +9,8 @@ import { twMerge } from "tailwind-merge";
 import { useShareConnection } from "~models/ShareConnection";
 import { timeAgo } from "~utils/time";
 import { Button } from "./Button";
-import { ClockIcon } from "@heroicons/react/24/outline";
 import { Dialog, DialogBody, DialogHeader } from "./Dialog";
+import { UserCircleIcon, ClockIcon } from "@heroicons/react/20/solid";
 
 function usePeerUser(peer?: string) {
   const { invitations } = useShareConnection(["invitations"]);
@@ -44,12 +44,30 @@ export const EditHistoryItem = <
   const user = usePeerUser(history.peer);
   const date = new Date(history.instant);
   return (
-    <tr>
-      <td>{date.toLocaleTimeString()}</td>
-      <td>{user?.user.name}</td>
-      <td>{render(history.prev)}</td>
-      <td>{render(to)}</td>
-    </tr>
+    <section className="bg-zinc-700 p-2 rounded-md mb-4 grid gap-2 grid-cols-2">
+      <p className="mr-4">
+        <UserCircleIcon
+          height={20}
+          className="inline mr-2"
+          aria-hidden="true"
+        />
+        <span className="sr-only">User: </span>
+        {user?.user.name}
+      </p>
+      <p>
+        <ClockIcon height={20} className="inline mr-2" aria-hidden="true" />
+        <span className="sr-only">Time: </span>
+        {date.toLocaleTimeString()}
+      </p>
+      <p>
+        <span>From </span>
+        {render(history.prev)}
+      </p>
+      <p>
+        <span>To </span>
+        {render(to)}
+      </p>
+    </section>
   );
 };
 
@@ -84,27 +102,15 @@ const EditHistoryDialog = <
     >
       <DialogHeader title="Edit History" onClose={onClose} />
       <DialogBody className="p-2">
-        <table className="w-full text-left table-fixed">
-          <thead>
-            <tr>
-              <th>Time</th>
-              <th>User</th>
-              <th>From</th>
-              <th>To</th>
-            </tr>
-          </thead>
-          <tbody>
-            {consistency.history.map((history, i) => (
-              <EditHistoryItem
-                register={consistency}
-                i={i}
-                render={render}
-                currentValue={value[valueKey]}
-                key={history.instant}
-              />
-            ))}
-          </tbody>
-        </table>
+        {consistency.history.map((history, i) => (
+          <EditHistoryItem
+            register={consistency}
+            i={i}
+            render={render}
+            currentValue={value[valueKey]}
+            key={history.instant}
+          />
+        ))}
       </DialogBody>
     </Dialog>
   );

--- a/src/components/EditHistory.tsx
+++ b/src/components/EditHistory.tsx
@@ -11,12 +11,17 @@ import { timeAgo } from "~utils/time";
 import { Button } from "./Button";
 import { Dialog, DialogBody, DialogHeader } from "./Dialog";
 import { UserCircleIcon, ClockIcon } from "@heroicons/react/20/solid";
+import { useShareProfile } from "~utils/hooks/share";
 
-function usePeerUser(peer?: string) {
+function usePeerUserName(peer?: string) {
+  const profile = useShareProfile();
   const { invitations } = useShareConnection(["invitations"]);
   return useMemo(
-    () => invitations.find((v) => v.user.key === peer),
-    [invitations, peer]
+    () =>
+      peer == profile.key
+        ? profile.name
+        : invitations.find((v) => v.user.key === peer)?.user.name,
+    [invitations, peer, profile.key, profile.name]
   );
 }
 
@@ -41,7 +46,7 @@ export const EditHistoryItem = <
 }: EditHistoryItemProps<T, K>) => {
   const history = register.history[i] as History<T, K>;
   const to = register.history[i + 1]?.prev ?? currentValue;
-  const user = usePeerUser(history.peer);
+  const user = usePeerUserName(history.peer);
   const date = new Date(history.instant);
   return (
     <section className="bg-zinc-700 p-2 rounded-md mb-4 grid gap-2 grid-cols-2">
@@ -52,7 +57,7 @@ export const EditHistoryItem = <
           aria-hidden="true"
         />
         <span className="sr-only">User: </span>
-        {user?.user.name}
+        {user}
       </p>
       <p>
         <ClockIcon height={20} className="inline mr-2" aria-hidden="true" />
@@ -138,7 +143,7 @@ export const EditHistory = <
   render,
 }: EditHistoryProps<T, K>) => {
   const consistency = value?.consistency[valueKey];
-  const user = usePeerUser(consistency?.peer);
+  const user = usePeerUserName(consistency?.peer);
   const [historyOpen, setHistoryOpen] = useState(false);
 
   if (!consistency || !value) {
@@ -164,7 +169,7 @@ export const EditHistory = <
             : "text-emerald-400"
         )}
       >
-        {user ? `${user.user.name}, ` : ""}
+        {user ? `${user}, ` : ""}
         {timeAgo(new Date(consistency.instant))}
       </p>
       <EditHistoryDialog

--- a/src/components/Incident.tsx
+++ b/src/components/Incident.tsx
@@ -73,8 +73,7 @@ export const Incident: React.FC<IncidentProps> = ({
   return (
     <>
       <EditIncidentDialog
-        incident={incident}
-        key={incident.id}
+        id={incident.id}
         open={editIncidentOpen}
         setOpen={setEditIncidentOpen}
       />

--- a/src/models/ShareConnection.ts
+++ b/src/models/ShareConnection.ts
@@ -265,11 +265,13 @@ const useShareConnectionInternal = create<ShareConnection>((set, get) => ({
 
         queryClient.invalidateQueries({ queryKey: ["incidents"] });
         queryClient.invalidateQueries({ queryKey: ["scratchpad"] });
+        queryClient.invalidateQueries({ queryKey: ["scratchpads"] });
         break;
       }
       case "scratchpad_update": {
         await setMatchScratchpad(data.id, data.scratchpad);
         queryClient.invalidateQueries({ queryKey: ["scratchpad"] });
+        queryClient.invalidateQueries({ queryKey: ["scratchpads"] });
         break;
       }
       case "server_user_add": {

--- a/src/pages/events/home/manage.tsx
+++ b/src/pages/events/home/manage.tsx
@@ -5,6 +5,7 @@ import { deleteManyIncidents, getIncidentsByEvent } from "~utils/data/incident";
 import {
   acceptEventInvitation,
   fetchInvitation,
+  forceEventInvitationSync,
   getInstancesForEvent,
   getIntegrationAPIEndpoints,
   getRequestCodeUserKey,
@@ -400,7 +401,7 @@ export const ProfilePrompt: React.FC = () => {
 };
 
 export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
-  const { name } = useShareProfile();
+  const { name, key } = useShareProfile();
 
   // Dialogs
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
@@ -416,6 +417,21 @@ export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
     "forceSync",
     "disconnect",
   ]);
+
+  // If we are not in the instance, force an invalidation
+  useEffect(() => {
+    if (!invitation?.accepted) {
+      return;
+    }
+
+    const instanceInList = connection.invitations.some(
+      (inv) => inv.user.key === key
+    );
+
+    if (!instanceInList) {
+      forceEventInvitationSync(event.sku);
+    }
+  }, [invitation, connection.invitations, key, event.sku]);
 
   const { data: entries } = useEventIncidents(event.sku);
   const isSharing = useMemo(

--- a/src/pages/events/home/manage.tsx
+++ b/src/pages/events/home/manage.tsx
@@ -469,7 +469,8 @@ export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
     (connection.readyState !== ReadyState.Closed &&
       connection.readyState !== ReadyState.Open) ||
     isPendingRemoveUser ||
-    isCreateInstancePending;
+    isCreateInstancePending ||
+    (invitation?.accepted && connection.readyState !== ReadyState.Open);
 
   return (
     <section>
@@ -488,7 +489,7 @@ export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
         open={leaveDialogOpen}
         onClose={() => setLeaveDialogOpen(false)}
       />
-      <Spinner show={showSpinner} />
+
       <h2 className="font-bold">Sharing</h2>
       <p>Share Name: {name} </p>
       {isSharing ? (
@@ -524,6 +525,7 @@ export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
               </span>
             </p>
           </nav>
+          <Spinner show={showSpinner} />
           <ul className="mt-4">
             {connection.invitations.map((user) => (
               <li
@@ -583,6 +585,7 @@ export const ShareManager: React.FC<ManageTabProps> = ({ event }) => {
           >
             Join Existing
           </Button>
+          <Spinner show={showSpinner} />
         </section>
       ) : null}
     </section>

--- a/src/pages/shell.tsx
+++ b/src/pages/shell.tsx
@@ -214,9 +214,9 @@ const EventPicker: React.FC = () => {
         >
           <div className="flex-1 overflow-hidden whitespace-nowrap text-ellipsis">
             <p>{event ? event.name : "Select Event"}</p>
-            {showDiv && (
-              <p className="text-sm text-emerald-400">{selectedDiv?.name}</p>
-            )}
+            <p className="text-sm text-emerald-400">
+              {showDiv ? <span>{selectedDiv?.name}</span> : event?.sku}
+            </p>
           </div>
           <ChevronDownIcon className="w-5 h-5" />
         </div>

--- a/src/utils/data/robotevents.ts
+++ b/src/utils/data/robotevents.ts
@@ -1,0 +1,12 @@
+import { MatchData, rounds } from "robotevents";
+
+export const ELIMINATION_ROUNDS = [
+  rounds.RoundOf16,
+  rounds.Quarterfinals,
+  rounds.Semifinals,
+  rounds.Finals,
+] as number[];
+
+export function isMatchElimination(match: MatchData): boolean {
+  return ELIMINATION_ROUNDS.includes(match.round);
+}

--- a/src/utils/data/scratchpad.ts
+++ b/src/utils/data/scratchpad.ts
@@ -145,6 +145,7 @@ export function getDefaultScratchpad(
           game: "High Stakes",
           auto: "none",
           awp: { blue: false, red: false },
+          timeout_used: { blue: false, red: false },
         },
       });
     }

--- a/src/utils/data/share.ts
+++ b/src/utils/data/share.ts
@@ -185,6 +185,11 @@ export async function getEventInvitation(
   return body.data;
 }
 
+export async function forceEventInvitationSync(sku: string) {
+  await del(`invitation_${sku}`);
+  queryClient.invalidateQueries({ queryKey: ["event_invitation", sku] });
+}
+
 export async function verifyEventInvitation(
   sku: string
 ): Promise<UserInvitation | null> {

--- a/src/utils/hooks/robotevents.ts
+++ b/src/utils/hooks/robotevents.ts
@@ -257,17 +257,18 @@ export function logicalMatchComparison(a: MatchData, b: MatchData) {
 export function useEventMatches<T = Match[]>(
   eventData: EventData | null | undefined,
   division: number | null | undefined,
+  query?: operations["event_getDivisionMatches"]["parameters"]["query"],
   options?: HookQueryOptions<Match[], Error, T>
 ): UseQueryResult<T> {
   return useQuery({
-    queryKey: ["matches", eventData?.sku, division],
+    queryKey: ["matches", eventData?.sku, division, query],
     queryFn: async () => {
       if (!eventData || !division) {
         return [];
       }
 
       const event = new Event(eventData, client.api);
-      const matches = await event.matches(division);
+      const matches = await event.matches(division, query);
 
       if (!matches.data) {
         return [];
@@ -336,9 +337,14 @@ export function useEventMatch(
   division: number | null | undefined,
   match: number | null | undefined
 ): UseQueryResult<Match | undefined> {
-  return useEventMatches(event, division, {
-    select: (matches) => matches?.find((m) => m.id === match),
-  });
+  return useEventMatches(
+    event,
+    division,
+    {},
+    {
+      select: (matches) => matches?.find((m) => m.id === match),
+    }
+  );
 }
 
 export function useEventTeam(

--- a/src/utils/hooks/scratchpad.ts
+++ b/src/utils/hooks/scratchpad.ts
@@ -39,6 +39,29 @@ export function useMatchScratchpad<T extends MatchScratchpad>(
   });
 }
 
+export function useMatchScratchpads<T extends MatchScratchpad>(
+  matches?: MatchData[] | null
+) {
+  return useQuery({
+    queryKey: ["scratchpads", matches],
+    queryFn: async () => {
+      if (!matches) {
+        return [];
+      }
+
+      const scratchpads = await Promise.all(
+        matches.map(async (match) => {
+          const id = getScratchpadID(match);
+          const scratchpad = await getMatchScratchpad<T>(id);
+          return scratchpad ?? null;
+        })
+      );
+
+      return scratchpads;
+    },
+  });
+}
+
 export function useDefaultScratchpad<T extends MatchScratchpad>(
   match?: MatchData | null
 ) {
@@ -94,7 +117,10 @@ export function useUpdateMatchScratchpad<T extends MatchScratchpad>(
       connection.updateScratchpad(id, value!);
       queryClient.invalidateQueries({
         exact: true,
-        queryKey: [`scratchpad`, match],
+        queryKey: ["scratchpad", match],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["scratchpads"],
       });
     },
   });

--- a/worker/sync/src/routers/invitation.ts
+++ b/worker/sync/src/routers/invitation.ts
@@ -187,6 +187,20 @@ invitationRouter
 
     await setInvitation(env, invitation);
 
+    // Tell DO to send an update
+    const stub = env.INCIDENTS.get(
+      env.INCIDENTS.idFromString(invitation.instance_secret)
+    );
+    stub.broadcast(
+      {
+        type: "server_user_add",
+        user: request.user,
+        activeUsers: await stub.getActiveUsers(),
+        invitations: await stub.getInvitationList(),
+      },
+      { type: "server" }
+    );
+
     return response<APIPutInvitationAcceptResponseBody>({
       success: true,
       data: {


### PR DESCRIPTION
Couple of small fixes post demo:
* Handle external updates better when showing edit history of an incident or scratchpad.
* Make edit history more mobile friendly when showing edit history
* Broadcast user join and leave events earlier
* Improve UI when a user is removed from an instance
* Support timeout tracking for elims matches