### PR TITLE
Add general button to team popover

### DIFF
--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -142,7 +142,7 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
                     })
                   }
                 >
-                  <FlagIcon height={20} className="inline mr-2 " />
+                  <FlagIcon height={20} className="inline mr-2" />
                   General
                 </Button>
                 <Button

--- a/src/pages/events/home/teams.tsx
+++ b/src/pages/events/home/teams.tsx
@@ -134,6 +134,19 @@ export const EventTeamsTab: React.FC<EventTagProps> = ({ event }) => {
                 <hr className="mt-4 border-zinc-600" />
                 <Button
                   mode="normal"
+                  className="mt-4 bg-blue-600"
+                  onClick={() =>
+                    openNewIncidentDialog({
+                      team: team.number,
+                      outcome: "General",
+                    })
+                  }
+                >
+                  <FlagIcon height={20} className="inline mr-2 " />
+                  General
+                </Button>
+                <Button
+                  mode="normal"
                   className="mt-4"
                   onClick={() =>
                     openNewIncidentDialog({


### PR DESCRIPTION
<img width="407" alt="image" src="https://github.com/user-attachments/assets/decbeb90-9f84-47d9-9c1a-af176b95e18a" />

Adds "General" as a quick launch option from the team list popover.