### PR TITLE
fix: improve user profile manegement when offline

### DIFF
--- a/src/routes/$sku/$division/-tabs/manage.tsx
+++ b/src/routes/$sku/$division/-tabs/manage.tsx
@@ -829,8 +829,8 @@ const SystemKeyIntegrationInfo: React.FC<SystemKeyIntegrationInfoProps> = ({
 
 const SystemKeyInfo: React.FC<ManageTabProps> = ({ event }) => {
   const {
-    profile: { isSystemKey },
-  } = useShareConnection(["profile"]);
+    userMetadata: { isSystemKey },
+  } = useShareConnection(["userMetadata"]);
 
   const { data: response, isLoading } = useQuery({
     queryKey: ["@referee-fyi", "get_instance_list", event.sku],

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -12,9 +12,10 @@ import { isWorldsBuild } from "~utils/data/state";
 import { clearCache } from "~utils/sentry";
 
 export const SettingsPage: React.FC = () => {
-  const { updateProfile, profile } = useShareConnection([
+  const { updateProfile, profile, userMetadata } = useShareConnection([
     "updateProfile",
     "profile",
+    "userMetadata",
   ]);
   const [localName, setLocalName] = useState(profile?.name ?? "");
 
@@ -57,7 +58,7 @@ export const SettingsPage: React.FC = () => {
         <h2 className="font-bold">Public Key</h2>
         <ClickToCopy message={profile?.key ?? ""} />
       </section>
-      {profile.isSystemKey ? (
+      {userMetadata.isSystemKey ? (
         <Info message="System Key Enabled" className="mt-4" />
       ) : null}
       <section className="mt-4">


### PR DESCRIPTION
Ensures that user name and public key appear in the UI even when the user is offline or has very slow internet. Seperates out the server-dependant registration phase from the local only share name management