### PR TITLE
Add Introspection Information to the Integration API

### DIFF
--- a/types/generated/worker/sync/openapi.d.ts
+++ b/types/generated/worker/sync/openapi.d.ts
@@ -2151,6 +2151,22 @@ export interface components {
             data: {
                 /** @enum {boolean} */
                 valid: true;
+                /** @description The user associated with this integration token. */
+                user: {
+                    key: string;
+                    name: string;
+                    /** @enum {string} */
+                    role: "none" | "system";
+                };
+                /** @description The invitation associated with this integration token. */
+                invitation: {
+                    id: string;
+                    sku: string;
+                    admin: boolean;
+                    user: string;
+                    accepted: boolean;
+                    from: string;
+                };
             };
         };
         /** @description Error response schema */

--- a/worker/sync/src/api/integration/v1/$sku/asset.ts
+++ b/worker/sync/src/api/integration/v1/$sku/asset.ts
@@ -22,16 +22,20 @@ export const QuerySchema = z.object({
   ...VerifyIntegrationTokenQuerySchema.shape,
 });
 
+export const AssetInformationSchema = z
+  .object({
+    type: AssetTypeSchema,
+    owner: UserSchema,
+    sku: z.string(),
+    url: z.url(),
+    expires_at: z.string(),
+  })
+  .meta({ id: "AssetInformation" });
+
 export const SuccessResponseSchema = z
   .object({
     success: z.literal(true),
-    data: z.object({
-      type: AssetTypeSchema,
-      owner: UserSchema,
-      sku: z.string(),
-      url: z.url(),
-      expires_at: z.string(),
-    }),
+    data: AssetInformationSchema,
   })
   .meta({
     id: "GetIntegrationV1AssetResponse",

--- a/worker/sync/src/api/integration/v1/$sku/users.ts
+++ b/worker/sync/src/api/integration/v1/$sku/users.ts
@@ -20,16 +20,23 @@ import {
 export const ParamsSchema = VerifyIntegrationTokenParamsSchema;
 export const QuerySchema = VerifyIntegrationTokenQuerySchema;
 
+export const InstanceUsersSchema = z
+  .object({
+    invitations: z.array(InvitationListItemSchema),
+    active: z.array(UserSchema).meta({
+      description:
+        "The list of users who are current connected to the instance websocket.",
+    }),
+  })
+  .meta({
+    id: "InstanceUsers",
+    description: "Information about the current users in a shared instance.",
+  });
+
 export const SuccessResponseSchema = z
   .object({
     success: z.literal(true),
-    data: z.object({
-      invitations: z.array(InvitationListItemSchema),
-      active: z.array(UserSchema).meta({
-        description:
-          "The list of users who are current connected to the instance websocket.",
-      }),
-    }),
+    data: InstanceUsersSchema,
   })
   .meta({
     id: "GetIntegrationV1UsersResponse",

--- a/worker/sync/src/api/integration/v1/$sku/verify.ts
+++ b/worker/sync/src/api/integration/v1/$sku/verify.ts
@@ -10,6 +10,7 @@ import {
   VerifyIntegrationTokenQuerySchema,
 } from "../../../../utils/verify";
 import { createRoute, RouteHandler } from "@hono/zod-openapi";
+import { InvitationSchema, UserSchema } from "@referee-fyi/share";
 
 export const ParamsSchema = VerifyIntegrationTokenParamsSchema;
 export const QuerySchema = VerifyIntegrationTokenQuerySchema;
@@ -19,6 +20,19 @@ export const SuccessResponseSchema = z
     success: z.literal(true),
     data: z.object({
       valid: z.literal(true),
+      user: UserSchema.meta({
+        description: "The user associated with this integration token.",
+      }),
+      invitation: InvitationSchema.pick({
+        id: true,
+        sku: true,
+        admin: true,
+        user: true,
+        accepted: true,
+        from: true,
+      }).meta({
+        description: "The invitation associated with this integration token.",
+      }),
     }),
   })
   .meta({
@@ -68,11 +82,22 @@ export const handler: RouteHandler<typeof route, AppArgs> = async (c) => {
     );
   }
 
+  const invitation = verifyIntegrationToken.invitation;
+
   return c.json(
     {
       success: true,
       data: {
         valid: true,
+        user: verifyIntegrationToken.user,
+        invitation: {
+          id: invitation.id,
+          sku: invitation.sku,
+          user: invitation.user,
+          from: invitation.from,
+          admin: invitation.admin,
+          accepted: invitation.accepted,
+        },
       },
     } as const satisfies z.infer<typeof SuccessResponseSchema>,
     200

--- a/worker/sync/src/api/integration/v1/$sku/verify.ts
+++ b/worker/sync/src/api/integration/v1/$sku/verify.ts
@@ -15,25 +15,33 @@ import { InvitationSchema, UserSchema } from "@referee-fyi/share";
 export const ParamsSchema = VerifyIntegrationTokenParamsSchema;
 export const QuerySchema = VerifyIntegrationTokenQuerySchema;
 
+export const TokenIntrospectionDataSchema = z
+  .object({
+    valid: z.literal(true),
+    user: UserSchema.meta({
+      description: "The user associated with this integration token.",
+    }),
+    invitation: InvitationSchema.pick({
+      id: true,
+      sku: true,
+      admin: true,
+      user: true,
+      accepted: true,
+      from: true,
+    }).meta({
+      description: "The invitation associated with this integration token.",
+    }),
+  })
+  .meta({
+    id: "TokenIntrospectionData",
+    description:
+      "Contains information about the associated session of a validation integration token.",
+  });
+
 export const SuccessResponseSchema = z
   .object({
     success: z.literal(true),
-    data: z.object({
-      valid: z.literal(true),
-      user: UserSchema.meta({
-        description: "The user associated with this integration token.",
-      }),
-      invitation: InvitationSchema.pick({
-        id: true,
-        sku: true,
-        admin: true,
-        user: true,
-        accepted: true,
-        from: true,
-      }).meta({
-        description: "The invitation associated with this integration token.",
-      }),
-    }),
+    data: TokenIntrospectionDataSchema,
   })
   .meta({
     id: "GetIntegrationV1VerifyResponse",


### PR DESCRIPTION
This update allows token holders to introspect information about their session. This additional information is returned in the verify endpoint. It includes:
* The associated `User`
* The associated `Invitation`

Note that the Integration Bearer Token is unique to the combination of user and invitation, and requires that the invitation is active. If a user leaves a session, it invalidates their session.